### PR TITLE
修复 Windows 上 doctor 和 runtime 探测误报s

### DIFF
--- a/projects/product/services/buildr/docs/agent-runtime-adapters.md
+++ b/projects/product/services/buildr/docs/agent-runtime-adapters.md
@@ -88,7 +88,7 @@ Buildr 当前不定义或维护真实 Agent marker smoke、品牌通过状态或
 - Buildr 生成 root `CODEBUDDY.md`，其中包含 imperative ancestor-chain 读取指令和 source index；内容不得超过 WorkBuddy 5.2.5 已观察到的 8,000 字符 project guidance 上限。
 - WorkBuddy 5.2.5 安装源码的 first-match 顺序是 `CODEBUDDY.md`、`.codebuddy/CODEBUDDY.md`、`AGENTS.md`，只读取 workspace root 第一个存在的入口。非 Buildr 管理的 `CODEBUDDY.md` 会触发 conflict，Buildr 不覆盖也不静默降级。
 - Skills 与 install plans 使用 `.codebuddy/`。WorkBuddy 5.2.5 内置的 CodeBuddy CLI 2.106.4 文档和 Skills panel 源码都将当前工作目录的 workspace destination Skills root 声明为 `.codebuddy/skills/`；`.workbuddy/skills` 只出现在 sandbox 可写路径中，不能据此认定为发现入口。Rules 与 Skills 修改后都要开启新任务。
-- checker 读取 `/Applications/WorkBuddy.app` 的 bundle id/版本，并检查 bridge、Skills 和 install plans 的 projection 状态。
+- checker 在 macOS 读取 `/Applications/WorkBuddy.app` 的 bundle id/版本；其他平台只保留手动版本确认指引，并检查 bridge、Skills 和 install plans 的 projection 状态。
 - 兼容证据来自本机 app.asar 源码、随应用交付的 CodeBuddy CLI 文档/源码和运行时 intake；官方公开文档只覆盖产品与 Marketplace，未公开 project guidance 与工作目录 Skills discovery 的完整实现。
 
 ## Checker 与限制

--- a/projects/product/services/buildr/src/application/domains/commands.mjs
+++ b/projects/product/services/buildr/src/application/domains/commands.mjs
@@ -852,7 +852,26 @@ export function registerDomainsCommands(runtime) {
         encoding: 'utf8',
         timeout: 5000,
         windowsHide: true,
+        shell: process.platform === 'win32',
       });
+      if (versionCheck.error?.code === 'ENOENT') {
+        item.status = 'warning';
+        item.reason = 'command_version_probe_spawn_failed';
+        item.message = `无法启动版本探测命令 ${command.id}。`;
+        item.difference = { expected: command.version.constraint, actual: versionCheck.error.message };
+        addCommandsFinding(result, 'warning', 'commands.version_probe_spawn_failed', item.message, {
+          path: sources[0],
+          sources,
+          commandId: command.id,
+          executable: command.executable,
+          versionArgs: command.version.args,
+          installHint: command.installHint || null,
+          reason: item.reason,
+          provenance: effective.provenance,
+          suggestion: command.installHint || '确认该命令可执行，并在必要时使用 shell 或 cmd.exe 重新探测版本。',
+        });
+        continue;
+      }
       const output = `${versionCheck.stdout || ''}\n${versionCheck.stderr || ''}`.trim();
       const currentVersion = parseVersion(output);
       if (!currentVersion) {

--- a/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
+++ b/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
@@ -62,7 +62,20 @@ export function probeWorkspaceNodeRuntime(workspace, options = {}) {
   const nodeProbe = spawnSync(paths.node, ['-p', 'process.versions.node'], { encoding: 'utf8', timeout: 10_000 });
   const actualVersion = nodeProbe.status === 0 ? nodeProbe.stdout.trim() : null;
   const env = { ...process.env, PATH: `${paths.bin}${path.delimiter}${process.env.PATH || ''}` };
-  const npmProbe = spawnSync(paths.npm, ['--version'], { encoding: 'utf8', timeout: 10_000, env });
+  const npmExecutable = process.platform === 'win32'
+    ? path.join(paths.root, 'node_modules', 'npm', 'bin', 'npm-cli.js')
+    : paths.npm;
+  const npmProbe = process.platform === 'win32'
+    ? spawnSync(paths.node, [npmExecutable, '--version'], {
+        encoding: 'utf8',
+        timeout: 10_000,
+        env,
+      })
+    : spawnSync(npmExecutable, ['--version'], {
+        encoding: 'utf8',
+        timeout: 10_000,
+        env,
+      });
   const status = actualVersion === identity.version && npmProbe.status === 0 ? 'ready' : 'invalid';
   return {
     status,
@@ -171,7 +184,20 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
       bin: initial.paths.platform === 'win' ? stage : path.join(stage, 'bin'),
     };
     const nodeProbe = spawnSync(stagedPaths.node, ['-p', 'process.versions.node'], { encoding: 'utf8', timeout: 10_000 });
-    const npmProbe = spawnSync(stagedPaths.npm, ['--version'], { encoding: 'utf8', timeout: 10_000, env: { ...process.env, PATH: `${stagedPaths.bin}${path.delimiter}${process.env.PATH || ''}` } });
+    const npmExecutable = process.platform === 'win32'
+      ? path.join(stagedPaths.root, 'node_modules', 'npm', 'bin', 'npm-cli.js')
+      : stagedPaths.npm;
+    const npmProbe = process.platform === 'win32'
+      ? spawnSync(stagedPaths.node, [npmExecutable, '--version'], {
+          encoding: 'utf8',
+          timeout: 10_000,
+          env: { ...process.env, PATH: `${stagedPaths.bin}${path.delimiter}${process.env.PATH || ''}` },
+        })
+      : spawnSync(npmExecutable, ['--version'], {
+          encoding: 'utf8',
+          timeout: 10_000,
+          env: { ...process.env, PATH: `${stagedPaths.bin}${path.delimiter}${process.env.PATH || ''}` },
+        });
     if (nodeProbe.status !== 0 || nodeProbe.stdout.trim() !== initial.identity.version || npmProbe.status !== 0) {
       throw new Error(`Prepared Workspace Node runtime failed probe for ${initial.identity.version}.`);
     }

--- a/projects/product/services/buildr/src/infrastructure/runtime/adapter-contract.mjs
+++ b/projects/product/services/buildr/src/infrastructure/runtime/adapter-contract.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import process from 'node:process';
 import {
   ownerExecutable,
   runtimeFileMatches,
@@ -454,11 +455,17 @@ const DESCRIPTORS = [
       skills: { kind: 'vendor-root', implementation: 'filesystem-skills', root: '.codebuddy' },
       surfaces: [{ kind: 'desktop' }, { kind: 'cli', variant: 'desktop-bundled' }],
       activation: { rules: 'session-start', skills: 'session-start', reloadGuidance: 'Start a new WorkBuddy task after adding or changing Rules or Skills.' },
-      checker: {
-        kind: 'projection', implementation: 'projection', resultKey: 'workbuddy',
-        installationProbe: { kind: 'command', executable: 'defaults', args: ['read', '/Applications/WorkBuddy.app/Contents/Info', 'CFBundleIdentifier'], timeoutMs: 3000 },
-        versionProbe: { kind: 'command', executable: 'defaults', args: ['read', '/Applications/WorkBuddy.app/Contents/Info', 'CFBundleShortVersionString'], timeoutMs: 3000 },
-      },
+      checker: process.platform === 'darwin'
+        ? {
+            kind: 'projection', implementation: 'projection', resultKey: 'workbuddy',
+            installationProbe: { kind: 'command', executable: 'defaults', args: ['read', '/Applications/WorkBuddy.app/Contents/Info', 'CFBundleIdentifier'], timeoutMs: 3000 },
+            versionProbe: { kind: 'command', executable: 'defaults', args: ['read', '/Applications/WorkBuddy.app/Contents/Info', 'CFBundleShortVersionString'], timeoutMs: 3000 },
+          }
+        : {
+            kind: 'projection', implementation: 'projection', resultKey: 'workbuddy',
+            installationProbe: { kind: 'manual', guidance: 'Confirm WorkBuddy is installed on this platform and record the launcher path or installation location.' },
+            versionProbe: { kind: 'manual', guidance: 'Record the WorkBuddy version from the application About dialog or installer metadata on this platform.' },
+          },
     },
     recommendedCommands: recommendedCommands('workbuddy'),
     evidence: { rules: 'installed-source-code', skills: 'installed-product-docs-and-source' },

--- a/projects/product/services/buildr/test/commands-cli.integration.mjs
+++ b/projects/product/services/buildr/test/commands-cli.integration.mjs
@@ -7,9 +7,22 @@ import test from 'node:test';
 import YAML from 'yaml';
 
 const buildr = path.resolve('bin/buildr.mjs');
+const testAppDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-cli-appdata-'));
+const testNodeRuntimeSourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-cli-node-runtime-'));
+fs.cpSync(path.dirname(process.execPath), testNodeRuntimeSourceRoot, { recursive: true, dereference: true });
 
-function run(args, expected = 0) {
-  const result = spawnSync(process.execPath, [buildr, ...args], { encoding: 'utf8' });
+function run(args, expected = 0, env = {}) {
+  const result = spawnSync(process.execPath, [buildr, ...args], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BUILDR_NODE_RUNTIME_SOURCE_ROOT: testNodeRuntimeSourceRoot,
+      BUILDR_APP_DATA_DIR: testAppDataRoot,
+      LOCALAPPDATA: testAppDataRoot,
+      APPDATA: testAppDataRoot,
+      ...env,
+    },
+  });
   assert.equal(result.status, expected, `buildr ${args.join(' ')}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
   return result;
 }
@@ -110,4 +123,31 @@ test('Command 与 Component removal 在 Project 反向引用存在时零写入',
   run(['commands', 'remove', 'plain-tool', '--target', root]);
   run(['commands', 'remove', 'orphan-tool', '--target', root]);
   assert.deepEqual(YAML.parse(fs.readFileSync(commandManifest, 'utf8')).commands, []);
+});
+
+test('Windows shim version probe can resolve .cmd wrappers', (t) => {
+  if (process.platform !== 'win32') return;
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-commands-win-shim-'));
+  const shimDir = path.join(root, 'bin');
+  const originalPath = process.env.PATH;
+  fs.mkdirSync(shimDir, { recursive: true });
+  t.after(() => {
+    process.env.PATH = originalPath;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  fs.writeFileSync(
+    path.join(shimDir, 'shimtool.cmd'),
+    '@echo off\r\nif "%~1"=="--version" (\r\n  echo 1.2.3\r\n  exit /b 0\r\n)\r\necho shimtool\r\n',
+  );
+  process.env.PATH = `${shimDir};${originalPath || ''}`;
+
+  run(['init', '--target', root, '--name', 'commands-win-shim', '--profile', 'personal']);
+  run(['commands', 'add', 'shimtool', '--purpose', 'Windows shim fixture', '--executable', 'shimtool', '--version-constraint', '=1.2.3', '--version-args', '--version', '--target', root]);
+
+  const result = check(root);
+  const observation = result.observations.find((item) => item.id === 'shimtool');
+  assert.equal(observation?.version?.current, '1.2.3');
+  assert.equal(result.findings.some((item) => item.commandId === 'shimtool'), false);
 });

--- a/projects/product/services/buildr/test/verification/runtime/adapter-contract.mjs
+++ b/projects/product/services/buildr/test/verification/runtime/adapter-contract.mjs
@@ -134,6 +134,12 @@ assert.deepEqual(RUNTIME_ADAPTERS['trae-work'].traits.checker.prerequisites || [
 assert.equal(RUNTIME_ADAPTERS.workbuddy.traits.rules.maxChars, 8000);
 assert.equal(RUNTIME_ADAPTERS.workbuddy.traits.skills.root, '.codebuddy');
 assert.deepEqual(RUNTIME_ADAPTERS.workbuddy.traits.surfaces, [{ kind: 'desktop' }, { kind: 'cli', variant: 'desktop-bundled' }]);
+if (process.platform === 'darwin') {
+  assert.equal(RUNTIME_ADAPTERS.workbuddy.traits.checker.versionProbe.kind, 'command');
+} else {
+  assert.equal(RUNTIME_ADAPTERS.workbuddy.traits.checker.installationProbe.kind, 'manual');
+  assert.equal(RUNTIME_ADAPTERS.workbuddy.traits.checker.versionProbe.kind, 'manual');
+}
 assert.deepEqual(Object.keys(RUNTIME_ADAPTERS.workbuddy.evidence).sort(), ['rules', 'skills']);
 assert.ok(adapterDoc.includes('`.codebuddy/skills`'));
 
@@ -211,7 +217,7 @@ assert.throws(() => validateRuntimePlan({ ...valid, writes: [{ targetFile: path.
 const symlinkPlanRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-plan-symlink-'));
 const symlinkPlanOutside = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-plan-outside-'));
 fs.mkdirSync(path.join(symlinkPlanRoot, '.agents'), { recursive: true });
-fs.symlinkSync(symlinkPlanOutside, path.join(symlinkPlanRoot, '.agents', 'skills'), 'dir');
+fs.symlinkSync(symlinkPlanOutside, path.join(symlinkPlanRoot, '.agents', 'skills'), process.platform === 'win32' ? 'junction' : 'dir');
 const symlinkPlanTarget = path.join(symlinkPlanRoot, '.agents', 'skills', 'demo', 'SKILL.md');
 assert.throws(() => validateRuntimePlan({ ...valid, targetRoot: symlinkPlanRoot, writes: [{ targetFile: symlinkPlanTarget, content: 'bad' }] }, codex), /crosses a symbolic link/);
 assert.throws(() => validateRuntimePlan({ ...valid, targetRoot: symlinkPlanRoot, removals: [{ targetFile: symlinkPlanTarget }] }, codex), /crosses a symbolic link/);
@@ -254,7 +260,7 @@ const binaryPlan = createRuntimePlan({
 });
 const binaryResult = reconcileRuntimePlan(binaryPlan);
 assert.deepEqual(fs.readFileSync(binaryFile), Buffer.from([0, 255, 16]));
-assert.equal((fs.statSync(binaryFile).mode & 0o100) === 0o100, true);
+if (process.platform !== 'win32') assert.equal((fs.statSync(binaryFile).mode & 0o100) === 0o100, true);
 assert.equal(fs.existsSync(staleFile), false);
 assert.equal(binaryResult.changed.at(-1), receiptFile, 'commitLast receipt must be written after payload files and stale removals');
 

--- a/projects/product/services/buildr/test/verification/runtime/adapter-parity.mjs
+++ b/projects/product/services/buildr/test/verification/runtime/adapter-parity.mjs
@@ -12,6 +12,9 @@ import { RUNTIME_ADAPTERS, runtimeAdapterImplementationMatrix } from '../../../s
 const productRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const buildr = path.join(productRoot, 'bin', 'buildr.mjs');
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-parity-'));
+const testAppDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-parity-appdata-'));
+const testNodeRuntimeSourceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-parity-node-runtime-'));
+fs.cpSync(path.dirname(process.execPath), testNodeRuntimeSourceRoot, { recursive: true, dereference: true });
 const commandTimings = new Map();
 
 function recordCommandTiming(args, startedAt) {
@@ -22,7 +25,18 @@ function recordCommandTiming(args, startedAt) {
 
 function run(args, options = {}) {
   const startedAt = Date.now();
-  const result = spawnSync(process.execPath, [buildr, ...args], { cwd: productRoot, encoding: 'utf8', env: { ...process.env, ...(options.env || {}) } });
+  const result = spawnSync(process.execPath, [buildr, ...args], {
+    cwd: productRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BUILDR_NODE_RUNTIME_SOURCE_ROOT: testNodeRuntimeSourceRoot,
+      BUILDR_APP_DATA_DIR: testAppDataRoot,
+      LOCALAPPDATA: testAppDataRoot,
+      APPDATA: testAppDataRoot,
+      ...(options.env || {}),
+    },
+  });
   recordCommandTiming(args, startedAt);
   if (!options.allowFailure && result.status !== 0) throw new Error(`${args.join(' ')} failed:\n${result.stdout}\n${result.stderr}`);
   return result;
@@ -31,7 +45,17 @@ function run(args, options = {}) {
 function runAsync(args, options = {}) {
   return new Promise((resolve, reject) => {
     const startedAt = Date.now();
-    const child = spawn(process.execPath, [buildr, ...args], { cwd: productRoot, env: { ...process.env, ...(options.env || {}) } });
+    const child = spawn(process.execPath, [buildr, ...args], {
+      cwd: productRoot,
+      env: {
+        ...process.env,
+        BUILDR_NODE_RUNTIME_SOURCE_ROOT: testNodeRuntimeSourceRoot,
+        BUILDR_APP_DATA_DIR: testAppDataRoot,
+        LOCALAPPDATA: testAppDataRoot,
+        APPDATA: testAppDataRoot,
+        ...(options.env || {}),
+      },
+    });
     let stdout = '';
     let stderr = '';
     child.stdout.setEncoding('utf8');
@@ -75,7 +99,7 @@ async function verifySkillSymlinkGuard() {
   const symlinkOutside = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-outside-'));
   await runAsync(['init', '--target', symlinkWorkspace, '--name', 'runtime-symlink']);
   fs.mkdirSync(path.join(symlinkWorkspace, '.agents'), { recursive: true });
-  fs.symlinkSync(symlinkOutside, path.join(symlinkWorkspace, '.agents', 'skills'), 'dir');
+  fs.symlinkSync(symlinkOutside, path.join(symlinkWorkspace, '.agents', 'skills'), process.platform === 'win32' ? 'junction' : 'dir');
   const symlinkInstall = await runAsync(['skill', 'install', 'codex', '--target', symlinkWorkspace], { allowFailure: true });
   assert.notEqual(symlinkInstall.status, 0, 'runtime install must reject a target path that crosses a symbolic link');
   assert.equal(fs.existsSync(path.join(symlinkOutside, 'buildr', 'SKILL.md')), false, 'runtime install must not write outside the workspace through a symbolic link');
@@ -85,7 +109,7 @@ async function verifyRulesSymlinkGuard() {
   const rulesSymlinkWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-rules-symlink-'));
   const rulesSymlinkOutside = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-runtime-rules-outside-'));
   await runAsync(['init', '--target', rulesSymlinkWorkspace, '--name', 'runtime-rules-symlink']);
-  fs.symlinkSync(rulesSymlinkOutside, path.join(rulesSymlinkWorkspace, '.cursor'), 'dir');
+  fs.symlinkSync(rulesSymlinkOutside, path.join(rulesSymlinkWorkspace, '.cursor'), process.platform === 'win32' ? 'junction' : 'dir');
   const symlinkRulesRender = await runAsync(['rules', 'render', 'cursor', '--scope', '.', '--target', rulesSymlinkWorkspace], { allowFailure: true });
   assert.notEqual(symlinkRulesRender.status, 0, 'runtime rules render must reject a target path that crosses a symbolic link');
   assert.equal(fs.existsSync(path.join(rulesSymlinkOutside, 'rules', 'buildr.mdc')), false, 'rules render must not write outside the workspace through a symbolic link');
@@ -193,7 +217,9 @@ for (const agent of supportedAdapters) {
     assert.ok(fs.existsSync(path.join(completeRuntime, ...relative.split('/'))), `${agent} must render ${relative}`);
   }
   assert.deepEqual(fs.readFileSync(path.join(completeRuntime, 'assets', 'sample.bin')), Buffer.from([0, 255, 16, 128]), `${agent} must preserve binary bytes`);
-  assert.equal((fs.statSync(path.join(completeRuntime, 'scripts', 'run.sh')).mode & 0o100) === 0o100, true, `${agent} must preserve owner executable intent`);
+  if (process.platform !== 'win32') {
+    assert.equal((fs.statSync(path.join(completeRuntime, 'scripts', 'run.sh')).mode & 0o100) === 0o100, true, `${agent} must preserve owner executable intent`);
+  }
   assert.ok(fs.existsSync(path.join(workspace, root, 'buildr', 'skill-projection-receipts', agent, 'complete-runtime-skill.json')), `${agent} must record an adapter-specific projection receipt`);
   const adapterDoctor = JSON.parse(run(['doctor', '--agent', agent, '--target', workspace, '--json']).stdout);
   assert.equal(adapterDoctor.agentRuntime.requested, agent, `${agent} doctor must inspect the requested adapter`);


### PR DESCRIPTION
## Summary

- User or Agent problem:
  Windows 上 `buildr doctor` 和相关 runtime 校验会把平台差异误判成告警，导致 `.cmd` 命令探测、WorkBuddy 探测和 Workspace Node runtime 校验出现假阳性。
- Result:
  已修复 Windows 平台下的误报，并补齐回归测试和文档说明。

## Contract

- OpenSpec change, or reason this is code-only:
  这是代码修复，不涉及产品契约变更。
- Compatibility and migration notes:
  保持现有 CLI 行为不变，仅修正 Windows 下的探测方式和诊断分类。
  WorkBuddy 在非 macOS 平台改为手动说明，不再硬跑 `defaults`。
  Windows 下命令版本探测和 Workspace Node runtime 校验改为兼容 `.cmd` / `npm-cli.js` 的方式。

## Verification

- [x] `node --test test/commands-cli.integration.mjs`
- [x] `node --test test/verification/runtime/adapter-contract.mjs`
- [x] `node --test test/verification/runtime/adapter-parity.mjs`
- [x] `git diff --check`
- [x] No private workspace data, credentials, generated runtime, or unrelated changes included