### PR TITLE
fix(runtime): 加固 Windows 离线 Node 安装

### DIFF
--- a/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
+++ b/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
@@ -10,15 +10,70 @@ import { localAppDataRoot } from './workspace-registry-repository.mjs';
 
 export const WORKSPACE_NODE_IDENTITY_SCHEMA = 'buildr.workspace-node-identity/v1';
 const INSTALL_TIMEOUT_MS = 180_000;
+const WINDOWS_FILESYSTEM_RETRY_TIMEOUT_MS = 5_000;
+const WINDOWS_FILESYSTEM_RETRY_DELAY_MS = 100;
+const TRANSIENT_WINDOWS_FILESYSTEM_ERRORS = new Set(['EACCES', 'EBUSY', 'EPERM']);
+
+function wait(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function runtimeFilesystemError(operation, target, error) {
+  const wrapped = new Error(`Workspace Node runtime ${operation} failed for ${target}: ${error.message}`, { cause: error });
+  for (const field of ['code', 'errno', 'syscall', 'path', 'dest']) {
+    if (error?.[field] !== undefined) wrapped[field] = error[field];
+  }
+  wrapped.operation = operation;
+  wrapped.target = target;
+  return wrapped;
+}
+
+export function runRuntimeFilesystemOperation(operation, target, action, options = {}) {
+  const platform = options.platform || process.platform;
+  const windows = platform === 'win32' || platform === 'win';
+  const now = options.filesystemRetryNow || Date.now;
+  const pause = options.filesystemRetryWait || wait;
+  const timeoutMs = options.filesystemRetryTimeoutMs ?? WINDOWS_FILESYSTEM_RETRY_TIMEOUT_MS;
+  const delayMs = options.filesystemRetryDelayMs ?? WINDOWS_FILESYSTEM_RETRY_DELAY_MS;
+  let deadline = null;
+  while (true) {
+    try {
+      return action();
+    } catch (error) {
+      if (!windows || !TRANSIENT_WINDOWS_FILESYSTEM_ERRORS.has(error?.code)) {
+        throw runtimeFilesystemError(operation, target, error);
+      }
+      const observedAt = now();
+      if (deadline === null) deadline = observedAt + timeoutMs;
+      else if (observedAt >= deadline) throw runtimeFilesystemError(operation, target, error);
+      pause(delayMs);
+    }
+  }
+}
 
 export function runtimeTreeRemovalOptions(platform = process.platform) {
-  return platform === 'win32'
+  return platform === 'win32' || platform === 'win'
     ? { recursive: true, force: true, maxRetries: 10, retryDelay: 100 }
     : { recursive: true, force: true };
 }
 
-function removeRuntimeTree(target) {
-  fs.rmSync(target, runtimeTreeRemovalOptions());
+function removeRuntimeTree(target, options = {}) {
+  return runRuntimeFilesystemOperation(
+    options.operation || 'remove-tree',
+    target,
+    () => fs.rmSync(target, runtimeTreeRemovalOptions(options.platform)),
+    options,
+  );
+}
+
+function copyRuntimeTree(source, target, options = {}) {
+  const copy = options.copyRuntimeTree || fs.cpSync;
+  return runRuntimeFilesystemOperation(
+    options.operation || 'copy-tree',
+    target,
+    () => copy(source, target, { recursive: true }),
+    options,
+  );
 }
 
 function sha256(value) {
@@ -59,6 +114,7 @@ export function workspaceNodeRuntimePaths(version, options = {}) {
     root,
     node: windows ? path.join(root, 'node.exe') : path.join(root, 'bin', 'node'),
     npm: windows ? path.join(root, 'npm.cmd') : path.join(root, 'bin', 'npm'),
+    npmCli: windows ? path.join(root, 'node_modules', 'npm', 'bin', 'npm-cli.js') : null,
     npx: windows ? path.join(root, 'npx.cmd') : path.join(root, 'bin', 'npx'),
     bin: windows ? root : path.join(root, 'bin'),
   };
@@ -68,11 +124,18 @@ function probeRuntimeCommand(executable, args, { platform, ...options } = {}) {
   return spawnCommandSync(executable, args, { ...options, platform: platform === 'win' ? 'win32' : platform });
 }
 
+function probeRuntimeNpm(paths) {
+  const env = { ...process.env, PATH: `${paths.bin}${path.delimiter}${process.env.PATH || ''}` };
+  return paths.platform === 'win'
+    ? probeRuntimeCommand(paths.node, [paths.npmCli, '--version'], { encoding: 'utf8', timeout: 10_000, env, platform: paths.platform })
+    : probeRuntimeCommand(paths.npm, ['--version'], { encoding: 'utf8', timeout: 10_000, env, platform: paths.platform });
+}
+
 export function probeWorkspaceNodeRuntime(workspace, options = {}) {
   const identity = workspaceNodeIdentity(workspace, options);
   if (!identity) return { status: 'missing-declaration', identity: null, executable: null, npmExecutable: null, actualVersion: null };
   const paths = workspaceNodeRuntimePaths(identity.version, options);
-  if (!fs.existsSync(paths.node) || !fs.existsSync(paths.npm)) {
+  if (!fs.existsSync(paths.node) || !fs.existsSync(paths.npm) || (paths.platform === 'win' && !fs.existsSync(paths.npmCli))) {
     return { status: 'missing', identity, executable: paths.node, npmExecutable: paths.npm, actualVersion: null, paths };
   }
   const nodeProbe = probeRuntimeCommand(paths.node, ['-p', 'process.versions.node'], {
@@ -81,13 +144,7 @@ export function probeWorkspaceNodeRuntime(workspace, options = {}) {
     platform: paths.platform,
   });
   const actualVersion = nodeProbe.status === 0 ? nodeProbe.stdout.trim() : null;
-  const env = { ...process.env, PATH: `${paths.bin}${path.delimiter}${process.env.PATH || ''}` };
-  const npmProbe = probeRuntimeCommand(paths.npm, ['--version'], {
-    encoding: 'utf8',
-    timeout: 10_000,
-    env,
-    platform: paths.platform,
-  });
+  const npmProbe = probeRuntimeNpm(paths);
   const status = actualVersion === identity.version && npmProbe.status === 0 ? 'ready' : 'invalid';
   return {
     status,
@@ -136,7 +193,7 @@ function installFromOfficial(version, stage, options = {}) {
     if (target.platform === 'win') {
       const command = `Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${temp.replaceAll("'", "''")}' -Force`;
       execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], { stdio: 'pipe', timeout: INSTALL_TIMEOUT_MS });
-      fs.cpSync(path.join(temp, descriptor.base), stage, { recursive: true });
+      copyRuntimeTree(path.join(temp, descriptor.base), stage, { ...options, platform: target.platform, operation: 'copy-official-distribution' });
     } else {
       execFileSync('tar', ['-xzf', archive, '--strip-components=1', '-C', stage], { stdio: 'pipe', timeout: INSTALL_TIMEOUT_MS });
     }
@@ -174,8 +231,10 @@ function renameRuntimeStage(stage, target, workspace, options) {
     } catch (error) {
       const winner = probeWorkspaceNodeRuntime(workspace, options);
       if (winner.status === 'ready') return winner;
-      if (!['EACCES', 'EBUSY', 'EPERM'].includes(error.code) || Date.now() >= deadline) throw error;
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+      if (!TRANSIENT_WINDOWS_FILESYSTEM_ERRORS.has(error.code) || Date.now() >= deadline) {
+        throw runtimeFilesystemError('publish-stage', target, error);
+      }
+      wait(50);
     }
   }
 }
@@ -196,12 +255,13 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
     throw new Error(`Workspace Node runtime install is locked: ${lock}`);
   }
   const stage = `${paths.root}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
+  let primaryError = null;
   try {
     const ready = probeWorkspaceNodeRuntime(workspace, options);
     if (ready.status === 'ready') return { ...ready, action: 'reused-after-lock' };
-    removeRuntimeTree(stage);
+    removeRuntimeTree(stage, { ...options, platform: initial.paths.platform, operation: 'remove-stale-stage' });
     const source = options.sourceRoot || process.env.BUILDR_NODE_RUNTIME_SOURCE_ROOT;
-    if (source) fs.cpSync(path.resolve(source), stage, { recursive: true });
+    if (source) copyRuntimeTree(path.resolve(source), stage, { ...options, platform: initial.paths.platform, operation: 'copy-source-to-stage' });
     else if (options.adoptCurrent === true && process.platform !== 'win32') installFromCurrent(stage, initial.identity.version);
     else installFromOfficial(initial.identity.version, stage, options);
     const stagedPaths = {
@@ -209,6 +269,7 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
       root: stage,
       node: initial.paths.platform === 'win' ? path.join(stage, 'node.exe') : path.join(stage, 'bin', 'node'),
       npm: initial.paths.platform === 'win' ? path.join(stage, 'npm.cmd') : path.join(stage, 'bin', 'npm'),
+      npmCli: initial.paths.platform === 'win' ? path.join(stage, 'node_modules', 'npm', 'bin', 'npm-cli.js') : null,
       bin: initial.paths.platform === 'win' ? stage : path.join(stage, 'bin'),
     };
     const nodeProbe = probeRuntimeCommand(stagedPaths.node, ['-p', 'process.versions.node'], {
@@ -216,25 +277,36 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
       timeout: 10_000,
       platform: initial.paths.platform,
     });
-    const npmProbe = probeRuntimeCommand(stagedPaths.npm, ['--version'], {
-      encoding: 'utf8',
-      timeout: 10_000,
-      env: { ...process.env, PATH: `${stagedPaths.bin}${path.delimiter}${process.env.PATH || ''}` },
-      platform: initial.paths.platform,
-    });
+    const npmProbe = probeRuntimeNpm(stagedPaths);
     if (nodeProbe.status !== 0 || nodeProbe.stdout.trim() !== initial.identity.version || npmProbe.status !== 0) {
       throw new Error(`Prepared Workspace Node runtime failed probe for ${initial.identity.version}.`);
     }
-    removeRuntimeTree(paths.root);
+    removeRuntimeTree(paths.root, { ...options, platform: initial.paths.platform, operation: 'remove-invalid-target' });
     const winner = renameRuntimeStage(stage, paths.root, workspace, options);
     if (winner) return { ...winner, action: 'reused-after-race' };
     const result = probeWorkspaceNodeRuntime(workspace, options);
     if (result.status !== 'ready') throw new Error(`Workspace Node runtime did not become ready for ${initial.identity.version}.`);
     return { ...result, action: initial.status === 'missing' ? 'installed' : 'repaired' };
+  } catch (error) {
+    primaryError = error;
+    throw error;
   } finally {
-    removeRuntimeTree(stage);
+    const cleanupErrors = [];
+    try {
+      removeRuntimeTree(stage, { ...options, platform: initial.paths.platform, operation: 'cleanup-stage' });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
     try { fs.closeSync(descriptor); } catch { /* already closed */ }
-    fs.rmSync(lock, { force: true });
+    try {
+      runRuntimeFilesystemOperation('release-lock', lock, () => fs.rmSync(lock, { force: true }), { ...options, platform: initial.paths.platform });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (cleanupErrors.length > 0) {
+      if (primaryError) primaryError.cleanupErrors = cleanupErrors;
+      else throw cleanupErrors[0];
+    }
   }
 }
 

--- a/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
+++ b/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
@@ -332,7 +332,7 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
   const paths = initial.paths;
   fs.mkdirSync(path.dirname(paths.root), { recursive: true });
   const lock = `${paths.root}.lock`;
-  const installLock = acquireRuntimeInstallLock(lock, workspace, { ...options, platform: paths.platform });
+  const installLock = acquireRuntimeInstallLock(lock, workspace, options);
   if (!installLock.owner) return { ...installLock.winner, action: 'reused-after-wait' };
   const stage = `${paths.root}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
   let primaryError = null;

--- a/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
+++ b/projects/product/services/buildr/src/infrastructure/filesystem/workspace-node-runtime.mjs
@@ -13,6 +13,8 @@ const INSTALL_TIMEOUT_MS = 180_000;
 const WINDOWS_FILESYSTEM_RETRY_TIMEOUT_MS = 5_000;
 const WINDOWS_FILESYSTEM_RETRY_DELAY_MS = 100;
 const TRANSIENT_WINDOWS_FILESYSTEM_ERRORS = new Set(['EACCES', 'EBUSY', 'EPERM']);
+const RUNTIME_INSTALL_LOCK_SCHEMA = 'buildr.workspace-node-runtime-install-lock/v1';
+const RUNTIME_INSTALL_LOCK_INITIALIZATION_GRACE_MS = 1_000;
 
 function wait(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -218,8 +220,92 @@ function installFromCurrent(stage, version) {
   if (fs.existsSync(npx)) fs.symlinkSync(fs.realpathSync(npx), path.join(bin, 'npx'));
 }
 
-function waitForLock(lock, deadline) {
-  while (fs.existsSync(lock) && Date.now() < deadline) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+function readRuntimeInstallLock(lock) {
+  try {
+    const raw = fs.readFileSync(lock, 'utf8');
+    const value = JSON.parse(raw);
+    const record = value?.schemaVersion === RUNTIME_INSTALL_LOCK_SCHEMA
+      && Number.isInteger(value.pid) && value.pid > 0
+      && typeof value.token === 'string' && value.token.length > 0
+      && typeof value.createdAt === 'string'
+      ? value
+      : null;
+    return { raw, record, modifiedAtMs: fs.statSync(lock).mtimeMs };
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    try { return { raw: null, record: null, modifiedAtMs: fs.statSync(lock).mtimeMs }; } catch { return null; }
+  }
+}
+
+function runtimeInstallOwnerAlive(pid, options = {}) {
+  if (options.runtimeInstallOwnerAlive) return options.runtimeInstallOwnerAlive(pid);
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code !== 'ESRCH';
+  }
+}
+
+function reclaimRuntimeInstallLock(lock, observed, options = {}) {
+  const current = readRuntimeInstallLock(lock);
+  if (!current || current.raw !== observed.raw || current.modifiedAtMs !== observed.modifiedAtMs) return false;
+  runRuntimeFilesystemOperation('reclaim-stale-lock', lock, () => fs.rmSync(lock, { force: true }), options);
+  return true;
+}
+
+export function acquireRuntimeInstallLock(lock, workspace, options = {}) {
+  const now = options.runtimeInstallLockNow || Date.now;
+  const pause = options.runtimeInstallLockWait || wait;
+  const timeoutMs = options.lockTimeoutMs ?? INSTALL_TIMEOUT_MS;
+  const deadline = now() + timeoutMs;
+  while (true) {
+    let descriptor;
+    try {
+      descriptor = fs.openSync(lock, 'wx');
+      const record = {
+        schemaVersion: RUNTIME_INSTALL_LOCK_SCHEMA,
+        pid: process.pid,
+        token: crypto.randomBytes(12).toString('hex'),
+        createdAt: new Date(now()).toISOString(),
+      };
+      fs.writeFileSync(descriptor, `${JSON.stringify(record)}\n`);
+      fs.closeSync(descriptor);
+      return { owner: true, file: lock, record, winner: null };
+    } catch (error) {
+      if (descriptor !== undefined) {
+        try { fs.closeSync(descriptor); } catch { /* already closed */ }
+      }
+      if (error.code !== 'EEXIST') throw runtimeFilesystemError('acquire-lock', lock, error);
+      const winner = probeWorkspaceNodeRuntime(workspace, options);
+      if (winner.status === 'ready') return { owner: false, file: lock, record: null, winner };
+      const observed = readRuntimeInstallLock(lock);
+      const observedAt = now();
+      const initializing = observed && !observed.record && observedAt - observed.modifiedAtMs < RUNTIME_INSTALL_LOCK_INITIALIZATION_GRACE_MS;
+      const ownerAlive = observed?.record ? runtimeInstallOwnerAlive(observed.record.pid, options) : false;
+      if (observed && !initializing && !ownerAlive) {
+        reclaimRuntimeInstallLock(lock, observed, options);
+        continue;
+      }
+      if (observedAt >= deadline) {
+        const owner = observed?.record ? `pid=${observed.record.pid} createdAt=${observed.record.createdAt}` : 'owner=initializing-or-unknown';
+        const error = new Error(`Workspace Node runtime install lock wait expired for ${lock}: ${owner}`);
+        error.code = 'workspace_node_runtime_install_locked';
+        error.operation = 'wait-for-lock';
+        error.target = lock;
+        throw error;
+      }
+      pause(Math.min(50, Math.max(1, deadline - observedAt)));
+    }
+  }
+}
+
+export function releaseRuntimeInstallLock(lock, options = {}) {
+  if (!lock?.owner) return false;
+  const current = readRuntimeInstallLock(lock.file);
+  if (!current?.record || current.record.token !== lock.record.token) return false;
+  runRuntimeFilesystemOperation('release-lock', lock.file, () => fs.rmSync(lock.file, { force: true }), options);
+  return true;
 }
 
 function renameRuntimeStage(stage, target, workspace, options) {
@@ -246,14 +332,8 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
   const paths = initial.paths;
   fs.mkdirSync(path.dirname(paths.root), { recursive: true });
   const lock = `${paths.root}.lock`;
-  const deadline = Date.now() + (options.lockTimeoutMs || 30_000);
-  waitForLock(lock, deadline);
-  let descriptor;
-  try { descriptor = fs.openSync(lock, 'wx'); } catch (error) {
-    const afterWait = probeWorkspaceNodeRuntime(workspace, options);
-    if (afterWait.status === 'ready') return { ...afterWait, action: 'reused-after-wait' };
-    throw new Error(`Workspace Node runtime install is locked: ${lock}`);
-  }
+  const installLock = acquireRuntimeInstallLock(lock, workspace, { ...options, platform: paths.platform });
+  if (!installLock.owner) return { ...installLock.winner, action: 'reused-after-wait' };
   const stage = `${paths.root}.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`;
   let primaryError = null;
   try {
@@ -297,9 +377,8 @@ export function ensureWorkspaceNodeRuntime(workspace, options = {}) {
     } catch (error) {
       cleanupErrors.push(error);
     }
-    try { fs.closeSync(descriptor); } catch { /* already closed */ }
     try {
-      runRuntimeFilesystemOperation('release-lock', lock, () => fs.rmSync(lock, { force: true }), { ...options, platform: initial.paths.platform });
+      releaseRuntimeInstallLock(installLock, { ...options, platform: initial.paths.platform });
     } catch (error) {
       cleanupErrors.push(error);
     }

--- a/projects/product/services/buildr/test/integration/workspace-node-runtime.test.mjs
+++ b/projects/product/services/buildr/test/integration/workspace-node-runtime.test.mjs
@@ -6,8 +6,10 @@ import test from 'node:test';
 
 import {
   ensureWorkspaceNodeRuntime,
+  acquireRuntimeInstallLock,
   normalizeNodePlatform,
   probeWorkspaceNodeRuntime,
+  releaseRuntimeInstallLock,
   runRuntimeFilesystemOperation,
   runtimeTreeRemovalOptions,
   workspaceNodeIdentity,
@@ -83,6 +85,78 @@ test('Windows runtime 文件操作会恢复瞬时 EPERM，并在耗尽后保留�
       && error.operation === 'cleanup-stage'
       && error.target === 'C:\\runtime.tmp'
       && /cleanup-stage failed/.test(error.message),
+  );
+});
+
+test('runtime install lock 等待活跃 owner，并回收已退出 owner 的遗留锁', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-node-runtime-lock-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const dataRoot = path.join(root, 'data');
+  const source = path.join(root, 'source');
+  fixtureRuntime(source);
+  const options = { dataRoot, platform: 'darwin', arch: 'arm64', sourceRoot: source };
+  const paths = workspaceNodeRuntimePaths(WORKSPACE.runtime.node.version, options);
+  fs.mkdirSync(path.dirname(paths.root), { recursive: true });
+  const lockFile = `${paths.root}.lock`;
+
+  const active = {
+    schemaVersion: 'buildr.workspace-node-runtime-install-lock/v1',
+    pid: 4242,
+    token: 'active-owner',
+    createdAt: '2026-08-12T00:00:00.000Z',
+  };
+  fs.writeFileSync(lockFile, `${JSON.stringify(active)}\n`);
+  let waits = 0;
+  const reused = acquireRuntimeInstallLock(lockFile, WORKSPACE, {
+    ...options,
+    runtimeInstallOwnerAlive: () => true,
+    runtimeInstallLockWait() {
+      waits += 1;
+      fixtureRuntime(paths.root);
+    },
+  });
+  assert.equal(reused.owner, false);
+  assert.equal(reused.winner.status, 'ready');
+  assert.equal(waits, 1);
+  fs.rmSync(lockFile, { force: true });
+  fs.rmSync(paths.root, { recursive: true, force: true });
+
+  const stale = { ...active, pid: 4343, token: 'stale-owner' };
+  fs.writeFileSync(lockFile, `${JSON.stringify(stale)}\n`);
+  const acquired = acquireRuntimeInstallLock(lockFile, WORKSPACE, {
+    ...options,
+    runtimeInstallOwnerAlive: () => false,
+  });
+  assert.equal(acquired.owner, true);
+  assert.notEqual(acquired.record.token, stale.token);
+  assert.equal(releaseRuntimeInstallLock(acquired, options), true);
+  assert.equal(fs.existsSync(lockFile), false);
+});
+
+test('runtime install lock 只允许当前 token 释放，等待耗尽保留 owner 诊断', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-node-runtime-lock-token-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const lockFile = path.join(root, 'runtime.lock');
+  const workspace = { ...WORKSPACE, runtime: { node: { version: '99.0.0' } } };
+  const owner = acquireRuntimeInstallLock(lockFile, workspace, { platform: 'darwin', dataRoot: root });
+  const replacement = { ...owner.record, token: 'replacement-owner' };
+  fs.writeFileSync(lockFile, `${JSON.stringify(replacement)}\n`);
+  assert.equal(releaseRuntimeInstallLock(owner, { platform: 'darwin' }), false);
+  assert.equal(fs.existsSync(lockFile), true);
+
+  let now = 0;
+  assert.throws(
+    () => acquireRuntimeInstallLock(lockFile, workspace, {
+      platform: 'darwin',
+      dataRoot: root,
+      lockTimeoutMs: 100,
+      runtimeInstallOwnerAlive: () => true,
+      runtimeInstallLockNow: () => now,
+      runtimeInstallLockWait: (milliseconds) => { now += milliseconds; },
+    }),
+    (error) => error.code === 'workspace_node_runtime_install_locked'
+      && error.operation === 'wait-for-lock'
+      && /pid=/.test(error.message),
   );
 });
 

--- a/projects/product/services/buildr/test/integration/workspace-node-runtime.test.mjs
+++ b/projects/product/services/buildr/test/integration/workspace-node-runtime.test.mjs
@@ -8,6 +8,7 @@ import {
   ensureWorkspaceNodeRuntime,
   normalizeNodePlatform,
   probeWorkspaceNodeRuntime,
+  runRuntimeFilesystemOperation,
   runtimeTreeRemovalOptions,
   workspaceNodeIdentity,
   workspaceNodeRuntimePaths,
@@ -26,8 +27,10 @@ function fixtureRuntime(root) {
 }
 
 function fixtureWindowsRuntime(root) {
-  fs.writeFileSync(path.join(root, 'node.exe'), '#!/bin/sh\nif [ "$1" = "-p" ]; then echo 22.4.1; else echo v22.4.1; fi\n', { mode: 0o755 });
-  fs.writeFileSync(path.join(root, 'npm.cmd'), '#!/bin/sh\necho 10.8.0\n', { mode: 0o755 });
+  fs.mkdirSync(path.join(root, 'node_modules/npm/bin'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'node.exe'), '#!/bin/sh\nif [ "$1" = "-p" ]; then echo 22.4.1; else echo 10.8.0; fi\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(root, 'npm.cmd'), '#!/bin/sh\nexit 99\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(root, 'node_modules/npm/bin/npm-cli.js'), '// fixture\n');
 }
 
 test('Workspace Node identity 不包含机器路径且按 platform/arch 稳定', () => {
@@ -47,7 +50,40 @@ test('Workspace Node runtime 临时目录在 Windows 使用 bounded EPERM retry'
     maxRetries: 10,
     retryDelay: 100,
   });
+  assert.deepEqual(runtimeTreeRemovalOptions('win'), runtimeTreeRemovalOptions('win32'));
   assert.deepEqual(runtimeTreeRemovalOptions('darwin'), { recursive: true, force: true });
+});
+
+test('Windows runtime 文件操作会恢复瞬时 EPERM，并在耗尽后保留操作诊断', () => {
+  let attempts = 0;
+  const waits = [];
+  const result = runRuntimeFilesystemOperation('copy-source-to-stage', 'C:\\runtime.tmp', () => {
+    attempts += 1;
+    if (attempts < 3) throw Object.assign(new Error('temporarily locked'), { code: 'EPERM' });
+    return 'copied';
+  }, {
+    platform: 'win32',
+    filesystemRetryWait: (milliseconds) => waits.push(milliseconds),
+  });
+  assert.equal(result, 'copied');
+  assert.equal(attempts, 3);
+  assert.deepEqual(waits, [100, 100]);
+
+  let now = 0;
+  assert.throws(
+    () => runRuntimeFilesystemOperation('cleanup-stage', 'C:\\runtime.tmp', () => {
+      throw Object.assign(new Error('still locked'), { code: 'EBUSY' });
+    }, {
+      platform: 'win32',
+      filesystemRetryTimeoutMs: 150,
+      filesystemRetryNow: () => now,
+      filesystemRetryWait: (milliseconds) => { now += milliseconds; },
+    }),
+    (error) => error.code === 'EBUSY'
+      && error.operation === 'cleanup-stage'
+      && error.target === 'C:\\runtime.tmp'
+      && /cleanup-stage failed/.test(error.message),
+  );
 });
 
 test('临时 App Data 只隔离应用状态，不改变 Workspace Node runtime locator', (t) => {
@@ -88,16 +124,29 @@ test('受管 runtime 从确定 source 原子准备、复用并在删除后按原
   assert.equal(restored.status, 'ready');
 });
 
-test('Windows 受管 runtime 通过 npm.cmd 探测', { skip: process.platform === 'win32' }, (t) => {
+test('Windows 受管 runtime 直接通过 node.exe 执行 npm CLI，并恢复 source copy 的瞬时 EPERM', { skip: process.platform === 'win32' }, (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-node-runtime-windows-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   const source = path.join(root, 'source');
   const dataRoot = path.join(root, 'data');
   fs.mkdirSync(source, { recursive: true });
   fixtureWindowsRuntime(source);
-  const options = { dataRoot, platform: 'win32', arch: 'x64', sourceRoot: source };
+  let copyAttempts = 0;
+  const options = {
+    dataRoot,
+    platform: 'win32',
+    arch: 'x64',
+    sourceRoot: source,
+    filesystemRetryWait: () => {},
+    copyRuntimeTree(from, to, copyOptions) {
+      copyAttempts += 1;
+      if (copyAttempts < 3) throw Object.assign(new Error('scanner lock'), { code: 'EPERM' });
+      fs.cpSync(from, to, copyOptions);
+    },
+  };
   const installed = ensureWorkspaceNodeRuntime(WORKSPACE, options);
   assert.equal(installed.status, 'ready');
+  assert.equal(copyAttempts, 3);
   assert.equal(probeWorkspaceNodeRuntime(WORKSPACE, options).npmVersion, '10.8.0');
 });
 

--- a/projects/product/services/buildr/test/integration/workspace-node-runtime.test.mjs
+++ b/projects/product/services/buildr/test/integration/workspace-node-runtime.test.mjs
@@ -133,6 +133,28 @@ test('runtime install lock 等待活跃 owner，并回收已退出 owner 的遗�
   assert.equal(fs.existsSync(lockFile), false);
 });
 
+test('Windows runtime 并发等待沿用 win32 探测参数', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-node-runtime-lock-windows-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const options = { dataRoot: path.join(root, 'data'), platform: 'win32', arch: 'x64' };
+  const paths = workspaceNodeRuntimePaths(WORKSPACE.runtime.node.version, options);
+  fs.mkdirSync(path.dirname(paths.root), { recursive: true });
+  fs.writeFileSync(`${paths.root}.lock`, `${JSON.stringify({
+    schemaVersion: 'buildr.workspace-node-runtime-install-lock/v1',
+    pid: 4242,
+    token: 'windows-owner',
+    createdAt: '2026-08-12T00:00:00.000Z',
+  })}\n`);
+
+  const reused = ensureWorkspaceNodeRuntime(WORKSPACE, {
+    ...options,
+    runtimeInstallOwnerAlive: () => true,
+    runtimeInstallLockWait: () => fixtureWindowsRuntime(paths.root),
+  });
+  assert.equal(reused.status, 'ready');
+  assert.equal(reused.action, 'reused-after-wait');
+});
+
 test('runtime install lock 只允许当前 token 释放，等待耗尽保留 owner 诊断', (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-node-runtime-lock-token-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/projects/product/services/buildr/test/verification/integrity/managed-mutations.mjs
+++ b/projects/product/services/buildr/test/verification/integrity/managed-mutations.mjs
@@ -33,7 +33,7 @@ const allowed = new Map([
   ])],
   ['src/infrastructure/filesystem/workspace-registry-repository.mjs', new Set(['withWorkspaceRegistryMutation'])],
   ['src/infrastructure/filesystem/workspace-node-runtime.mjs', new Set([
-    'downloadFile', 'removeRuntimeTree', 'installFromOfficial', 'installFromCurrent', 'renameRuntimeStage', 'ensureWorkspaceNodeRuntime',
+    'downloadFile', 'removeRuntimeTree', 'copyRuntimeTree', 'installFromOfficial', 'installFromCurrent', 'renameRuntimeStage', 'ensureWorkspaceNodeRuntime',
   ])],
   ['src/infrastructure/filesystem/task-execution-record-body-store.mjs', new Set([
     'syncFile', 'publishTaskExecutionRecordBody', 'cleanupTaskExecutionRecordBody',

--- a/projects/product/services/buildr/test/verification/integrity/managed-mutations.mjs
+++ b/projects/product/services/buildr/test/verification/integrity/managed-mutations.mjs
@@ -33,7 +33,7 @@ const allowed = new Map([
   ])],
   ['src/infrastructure/filesystem/workspace-registry-repository.mjs', new Set(['withWorkspaceRegistryMutation'])],
   ['src/infrastructure/filesystem/workspace-node-runtime.mjs', new Set([
-    'downloadFile', 'removeRuntimeTree', 'copyRuntimeTree', 'installFromOfficial', 'installFromCurrent', 'renameRuntimeStage', 'ensureWorkspaceNodeRuntime',
+    'downloadFile', 'removeRuntimeTree', 'copyRuntimeTree', 'reclaimRuntimeInstallLock', 'acquireRuntimeInstallLock', 'releaseRuntimeInstallLock', 'installFromOfficial', 'installFromCurrent', 'renameRuntimeStage', 'ensureWorkspaceNodeRuntime',
   ])],
   ['src/infrastructure/filesystem/task-execution-record-body-store.mjs', new Set([
     'syncFile', 'publishTaskExecutionRecordBody', 'cleanupTaskExecutionRecordBody',

--- a/projects/product/services/buildr/test/verification/registry.mjs
+++ b/projects/product/services/buildr/test/verification/registry.mjs
@@ -295,6 +295,7 @@ export const verificationSteps = Object.freeze([
     'test/system/task-environment-fresh-build-web.test.mjs',
     'test/system/task-finish-cli.test.mjs',
     'test/system/task-finish-product-journey.test.mjs',
+    'test/system/workspace-runtime-recovery.test.mjs',
     'test/system/worktree-create.test.mjs',
   ], args: ['--test-concurrency=1', '--test-reporter=dot'] }, groups: ['windows-platform-preflight'], selection: 'explicit-only', inputs: [
     'test/system/cli-update.test.mjs',
@@ -302,6 +303,7 @@ export const verificationSteps = Object.freeze([
     'test/system/local-app-launcher.test.mjs',
     'test/system/task-environment-fresh-build-web.test.mjs',
     'test/system/task-finish-*.test.mjs',
+    'test/system/workspace-runtime-recovery.test.mjs',
     'test/system/worktree-create.test.mjs',
     'test/helpers/task-finish-sqlite-fixture.mjs',
     'src/application/cli-update.mjs',


### PR DESCRIPTION
## 目标

修复 Windows 离线 Workspace Node 安装在复制、探测、原子切换和清理阶段的瞬时文件占用问题。

## 验证

- Quick 通过
- affected 通过（175.150 秒；registry 变化按策略扩展为 full）
- System runtime recovery 通过（13.840 秒）
- 本 PR 用于取得 Windows 24.15.0 / 24.x 平台预检证据
