### PR TITLE
fix(preview): 修复启动失败回收与 rc.29 验证入口

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           BUILDR_TIMING_OUTPUT: ${{ runner.temp }}/development-feedback-timing.json
           BUILDR_DIAGNOSTICS_OUTPUT: ${{ runner.temp }}/development-feedback-diagnostics
-          BUILDR_VERIFICATION_PROFILE: ci-workspace-limited
+          BUILDR_VERIFICATION_PROFILE: ci
         shell: bash
         run: npm run test:changed -- --base "${{ steps.base.outputs.sha }}"
       - name: Install Buildr Web dependencies

--- a/projects/product/services/buildr/src/web/application/preview-lifecycle.mjs
+++ b/projects/product/services/buildr/src/web/application/preview-lifecycle.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 import process from 'node:process';
+import { performance } from 'node:perf_hooks';
 
 import { buildrWebDataRoot } from '../../workspace/module.mjs';
 import { sameFilesystemPath } from '../../infrastructure/filesystem/filesystem-path-identity.mjs';
@@ -132,14 +133,36 @@ function clearOwner(name, dataRoot) {
   fs.rmSync(previewOwnerPath(name, dataRoot), { force: true });
 }
 
-async function waitForPreview(name, dataRoot, attempts = 80) {
-  for (let index = 0; index < attempts; index += 1) {
+// The deadline covers startup, not the number of probes; failed children stop
+// immediately. Retain the ChildProcess handle so failure cleanup never guesses
+// ownership from a stale PID file or another instance's port.
+async function waitForPreview(name, dataRoot, child, startup, timeoutMs) {
+  const began = performance.now();
+  startup.phase = 'instance-missing';
+  while (performance.now() - began < timeoutMs) {
+    if (startup.spawnError || child.exitCode !== null || child.signalCode !== null) break;
     const instance = readPreviewInstance(name, dataRoot);
-    const healthy = await healthyBuildrWebInstance(instance);
-    if (healthy) return healthy;
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    startup.phase = !instance ? 'instance-missing' : instance.pid !== child.pid ? 'instance-pid-mismatch' : 'health-not-ready';
+    const healthy = instance?.pid === child.pid ? await healthyBuildrWebInstance(instance) : null;
+    if (healthy && !startup.spawnError && child.exitCode === null && child.signalCode === null) return healthy;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(50, Math.max(0, timeoutMs - (performance.now() - began)))));
   }
+  startup.elapsedMs = Math.round(performance.now() - began);
   return null;
+}
+
+async function reclaimPreviewChild(child, startup) {
+  const exited = () => startup.spawnError || child.exitCode !== null || child.signalCode !== null;
+  if (exited()) return 'already-exited';
+  for (const signal of ['SIGTERM', 'SIGKILL']) {
+    if (!child.kill(signal) && !exited()) throw new Error(`无法发送 ${signal}：${startup.processError?.message || 'child.kill returned false'}`);
+    const deadline = performance.now() + 1000;
+    while (!exited() && performance.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    if (exited()) return 'terminated';
+  }
+  throw new Error('预览子进程在终止信号后仍未确认退出。');
 }
 
 function requestInstanceShutdown(instance) {
@@ -196,7 +219,7 @@ function taskPreviewResource(owner, instance) {
   };
 }
 
-export async function startPreview(runtime, name, args, { cliPath = process.argv[1], dataRoot = buildrWebDataRoot() } = {}) {
+export async function startPreview(runtime, name, args, { cliPath = process.argv[1], dataRoot = buildrWebDataRoot(), startupTimeoutMs = 10_000 } = {}) {
   const instance = assertPreviewName(name);
   runtime.assertNoUnknownOptions(args, new Set(['--target', '--task', '--port', '--no-open', '--json']), new Set(['--no-open', '--json']));
   const requestedRoot = path.resolve(runtime.optionValue(args, '--target', process.cwd()));
@@ -274,14 +297,33 @@ export async function startPreview(runtime, name, args, { cliPath = process.argv
   } finally {
     fs.closeSync(logDescriptor);
   }
+  const startup = { spawnError: null };
+  child.on('error', (error) => {
+    if (!child.pid) startup.spawnError = error;
+    else startup.processError = error;
+  });
   child.unref();
-  const started = await waitForPreview(instance, dataRoot);
+  const started = await waitForPreview(instance, dataRoot, child, startup, startupTimeoutMs);
   if (!started) {
+    const failed = Boolean(startup.spawnError || child.exitCode !== null || child.signalCode !== null);
+    const exitCode = child.exitCode;
+    const signal = child.signalCode;
+    let cleanup;
+    try {
+      cleanup = await reclaimPreviewChild(child, startup);
+      const state = readPreviewInstance(instance, dataRoot);
+      if (state?.pid === child.pid) fs.rmSync(previewInstancePath(instance, dataRoot), { force: true });
+      clearOwner(instance, dataRoot);
+    } catch (error) {
+      cleanup = error.message;
+      writeOwner(runtime, { ...owner, managedProcess: { pid: child.pid, state: 'cleanup-failed' } }, dataRoot);
+    }
     let diagnostic = null;
     try { diagnostic = fs.readFileSync(logFile, 'utf8').trim().slice(-4096) || null; } catch {}
-    const error = new Error(`预览实例 ${instance} 未在预期时间内就绪。${diagnostic ? `\n${diagnostic}` : ''}`);
-    error.code = 'preview_start_timeout';
-    error.details = { instance, logFile, diagnostic };
+    const reason = failed ? '启动进程提前退出或无法创建' : '未在预期时间内就绪';
+    const error = new Error(`预览实例 ${instance} ${reason}。pid=${child.pid ?? 'none'} phase=${startup.phase} elapsedMs=${startup.elapsedMs} exitCode=${exitCode} signal=${signal} cleanup=${cleanup}${startup.spawnError ? ` spawnError=${startup.spawnError.message}` : ''}${diagnostic ? `\n${diagnostic}` : ''}`);
+    error.code = !['terminated', 'already-exited'].includes(cleanup) ? 'preview_start_cleanup_failed' : failed ? 'preview_start_failed' : 'preview_start_timeout';
+    error.details = { instance, pid: child.pid ?? null, phase: startup.phase, elapsedMs: startup.elapsedMs, exitCode, signal, cleanup, logFile, diagnostic };
     throw error;
   }
   const managedOwner = {

--- a/projects/product/services/buildr/src/web/application/preview-lifecycle.mjs
+++ b/projects/product/services/buildr/src/web/application/preview-lifecycle.mjs
@@ -312,7 +312,7 @@ export async function startPreview(runtime, name, args, { cliPath = process.argv
     try {
       cleanup = await reclaimPreviewChild(child, startup);
       const state = readPreviewInstance(instance, dataRoot);
-      if (state?.pid === child.pid) fs.rmSync(previewInstancePath(instance, dataRoot), { force: true });
+      if (state?.pid === child.pid) runtime.removePath(previewInstancePath(instance, dataRoot));
       clearOwner(instance, dataRoot);
     } catch (error) {
       cleanup = error.message;

--- a/projects/product/services/buildr/test/contract/infrastructure-boundaries.test.mjs
+++ b/projects/product/services/buildr/test/contract/infrastructure-boundaries.test.mjs
@@ -21,9 +21,10 @@ test('Infrastructure 只保留技术机制入口，业务 Persistence 归属 Tas
     'src/infrastructure/sqlite/task-verification-repository.mjs',
     'src/infrastructure/filesystem/task-environment-repository.mjs',
     'src/infrastructure/filesystem/task-execution-record-body-store.mjs',
+    'src/task/persistence/parent-coordination-repository.mjs',
   ]) assert.equal(fs.existsSync(path.join(root, relative)), false, relative);
   for (const relative of [
-    'src/task/persistence/parent-coordination-repository.mjs',
+    'src/task/persistence/task-record-repository.mjs',
     'src/task/persistence/task-development-repository.mjs',
     'src/task/persistence/task-environment-repository.mjs',
     'src/task/persistence/task-execution-record-repository.mjs',
@@ -47,9 +48,10 @@ test('Bootstrap 只组装 Infrastructure，Task module 私有组装各自 Persis
   for (const registration of [
     'registerTaskEnvironmentRepository', 'registerTaskExecutionRecordRepository',
     'registerTaskVerificationRepository', 'registerTaskDevelopmentRepository',
-    'registerParentCoordinationRepository', 'registerTaskOverviewRepository',
+    'registerTaskRecordRepository', 'registerTaskOverviewRepository',
     'registerTaskReviewRepository', 'registerTaskRetrospectiveRepository',
   ]) assert.match(taskModule, new RegExp(registration));
+  assert.doesNotMatch(taskModule, /registerParentCoordinationRepository/);
   assert.match(bootstrap, /registerInfrastructure/);
   assert.doesNotMatch(bootstrap, /legacy-runtime-module/);
   assert.doesNotMatch(bootstrap, /registerTaskPersistence|registerTaskEnvironmentRepository|registerTaskDevelopmentRepository/);

--- a/projects/product/services/buildr/test/helpers/workspace-product-suite.mjs
+++ b/projects/product/services/buildr/test/helpers/workspace-product-suite.mjs
@@ -621,11 +621,26 @@ suiteTest('app-process', 'buildr web 重复启动复用单实例并从陈旧 run
 });
 
 suiteTest('app-process', '独立 checkout preview 并行隔离、输出身份并只停止自身实例', { timeout: APP_PROCESS_TIMEOUT_MS }, async (t) => {
-  const base = temporaryRoot(t);
-  const appData = path.join(base, 'preview-data');
-  const env = { ...process.env, BUILDR_APP_DATA_DIR: appData };
+  const started = [];
   const timings = [];
   let currentPhase = 'setup';
+  let appData;
+  t.after(async () => {
+    const cleanupStartedAt = performance.now();
+    const errors = [];
+    for (const name of started) {
+      try { await stopPreview(name, { dataRoot: appData, caller: null }); } catch (error) {
+        if (error.code !== 'preview_not_found') errors.push(error);
+      }
+    }
+    timings.push(`cleanup=${Math.round(performance.now() - cleanupStartedAt)}ms`);
+    t.diagnostic(`[preview-isolation-timing] current=${currentPhase} ${timings.join(' ')}`);
+    if (errors.length) throw new AggregateError(errors, '预览测试进程清理失败');
+  });
+
+  const base = temporaryRoot(t);
+  appData = path.join(base, 'preview-data');
+  const env = { ...process.env, BUILDR_APP_DATA_DIR: appData };
   const measure = async (phase, operation) => {
     currentPhase = phase;
     const startedAt = performance.now();
@@ -638,19 +653,9 @@ suiteTest('app-process', '独立 checkout preview 并行隔离、输出身份并
   const runPreviewCommand = (phase, args) => measure(phase, () => runBuildr(args, { env, timeout: APP_COMMAND_TIMEOUT_MS }));
   const first = await measure('workspace-first', () => initGitWorkspace(t, { name: 'preview-first' }));
   const second = await measure('workspace-second', () => initGitWorkspace(t, { name: 'preview-second' }));
-  const started = [];
-  t.after(async () => {
-    const cleanupStartedAt = performance.now();
-    for (const name of started) {
-      try { await stopPreview(name, { dataRoot: appData, caller: null }); } catch { /* assertion path retains diagnostic */ }
-    }
-    timings.push(`cleanup=${Math.round(performance.now() - cleanupStartedAt)}ms`);
-    t.diagnostic(`[preview-isolation-timing] current=${currentPhase} ${timings.join(' ')}`);
-  });
-
+  started.push('first-task');
   const firstStart = await runPreviewCommand('start-first', ['web', 'preview', 'start', 'first-task', '--target', first, '--no-open', '--json']);
   assert.equal(firstStart.status, 0, firstStart.stderr);
-  started.push('first-task');
   const firstPreview = JSON.parse(firstStart.stdout);
   assert.equal(firstPreview.status, 'started');
   assert.equal(firstPreview.owner.worktree, first);
@@ -665,9 +670,9 @@ suiteTest('app-process', '独立 checkout preview 并行隔离、输出身份并
   assert.match(firstPage, /first-task/);
   assert.match(firstPage, /buildr-preview/);
 
+  started.push('second-task');
   const secondStart = await runPreviewCommand('start-second', ['web', 'preview', 'start', 'second-task', '--target', second, '--no-open', '--json']);
   assert.equal(secondStart.status, 0, secondStart.stderr);
-  started.push('second-task');
   const secondPreview = JSON.parse(secondStart.stdout);
   assert.notEqual(secondPreview.url, firstPreview.url);
   assert.equal(secondPreview.owner.worktree, second);

--- a/projects/product/services/buildr/test/helpers/workspace-product-suite.mjs
+++ b/projects/product/services/buildr/test/helpers/workspace-product-suite.mjs
@@ -16,8 +16,8 @@ export function registerWorkspaceProductSuite(selectedSuite) {
 
 const PRODUCT_ROOT = path.resolve(import.meta.dirname, '../..');
 const BUILDR = path.join(PRODUCT_ROOT, 'bin', 'buildr.mjs');
-const PREVIEW_ISOLATION_TIMEOUT_MS = 60_000;
-const PREVIEW_COMMAND_TIMEOUT_MS = 15_000;
+const APP_PROCESS_TIMEOUT_MS = 60_000;
+const APP_COMMAND_TIMEOUT_MS = 15_000;
 
 function temporaryRoot(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-workspace-product-'));
@@ -578,7 +578,7 @@ suiteTest('buildr-web-http', '全局 Buildr Web Runtime 隔离多个 Workspace�
   assert.equal(shutdown, true);
 });
 
-suiteTest('app-process', 'buildr web 重复启动复用单实例并从陈旧 runtime state 恢复', { timeout: 15_000 }, async (t) => {
+suiteTest('app-process', 'buildr web 重复启动复用单实例并从陈旧 runtime state 恢复', { timeout: APP_PROCESS_TIMEOUT_MS }, async (t) => {
   const base = temporaryRoot(t);
   const root = initWorkspace(t, { name: 'single-instance' });
   const appData = path.join(base, 'single-instance-data');
@@ -592,7 +592,7 @@ suiteTest('app-process', 'buildr web 重复启动复用单实例并从陈旧 run
   child.stderr.on('data', (chunk) => { errors += chunk; });
   t.after(() => { if (child.exitCode === null) child.kill('SIGTERM'); });
   await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`Buildr Web 未就绪：${output}\n${errors}`)), 5000);
+    const timeout = setTimeout(() => reject(new Error(`Buildr Web 未就绪：${output}\n${errors}`)), APP_COMMAND_TIMEOUT_MS);
     const poll = setInterval(() => {
       if (output.includes('Buildr Web：')) {
         clearTimeout(timeout);
@@ -608,8 +608,8 @@ suiteTest('app-process', 'buildr web 重复启动复用单实例并从陈旧 run
       }
     });
   });
-  const reused = spawnSync(process.execPath, [BUILDR, 'web', '--target', root, '--no-open'], { cwd: PRODUCT_ROOT, env, encoding: 'utf8', timeout: 5000 });
-  assert.equal(reused.status, 0, reused.stderr);
+  const reused = spawnSync(process.execPath, [BUILDR, 'web', '--target', root, '--no-open'], { cwd: PRODUCT_ROOT, env, encoding: 'utf8', timeout: APP_COMMAND_TIMEOUT_MS });
+  assert.equal(reused.status, 0, reused.stderr || reused.error?.message || `signal=${reused.signal}`);
   assert.match(reused.stdout, /Buildr Web 已运行/);
   child.kill('SIGTERM');
   await new Promise((resolve) => child.once('exit', resolve));
@@ -620,7 +620,7 @@ suiteTest('app-process', 'buildr web 重复启动复用单实例并从陈旧 run
   }
 });
 
-suiteTest('app-process', '独立 checkout preview 并行隔离、输出身份并只停止自身实例', { timeout: PREVIEW_ISOLATION_TIMEOUT_MS }, async (t) => {
+suiteTest('app-process', '独立 checkout preview 并行隔离、输出身份并只停止自身实例', { timeout: APP_PROCESS_TIMEOUT_MS }, async (t) => {
   const base = temporaryRoot(t);
   const appData = path.join(base, 'preview-data');
   const env = { ...process.env, BUILDR_APP_DATA_DIR: appData };
@@ -635,7 +635,7 @@ suiteTest('app-process', '独立 checkout preview 并行隔离、输出身份并
       timings.push(`${phase}=${Math.round(performance.now() - startedAt)}ms`);
     }
   };
-  const runPreviewCommand = (phase, args) => measure(phase, () => runBuildr(args, { env, timeout: PREVIEW_COMMAND_TIMEOUT_MS }));
+  const runPreviewCommand = (phase, args) => measure(phase, () => runBuildr(args, { env, timeout: APP_COMMAND_TIMEOUT_MS }));
   const first = await measure('workspace-first', () => initGitWorkspace(t, { name: 'preview-first' }));
   const second = await measure('workspace-second', () => initGitWorkspace(t, { name: 'preview-second' }));
   const started = [];

--- a/projects/product/services/buildr/test/helpers/workspace-product-suite.mjs
+++ b/projects/product/services/buildr/test/helpers/workspace-product-suite.mjs
@@ -16,7 +16,7 @@ export function registerWorkspaceProductSuite(selectedSuite) {
 
 const PRODUCT_ROOT = path.resolve(import.meta.dirname, '../..');
 const BUILDR = path.join(PRODUCT_ROOT, 'bin', 'buildr.mjs');
-const PREVIEW_ISOLATION_TIMEOUT_MS = process.platform === 'win32' ? 60_000 : 20_000;
+const PREVIEW_ISOLATION_TIMEOUT_MS = 60_000;
 const PREVIEW_COMMAND_TIMEOUT_MS = 15_000;
 
 function temporaryRoot(t) {

--- a/projects/product/services/buildr/test/integration/preview-ownership.test.mjs
+++ b/projects/product/services/buildr/test/integration/preview-ownership.test.mjs
@@ -95,7 +95,7 @@ else {
       if (req.method === 'POST') {
         res.writeHead(202).end();
         server.close(() => process.exit(0));
-      } else { res.end(JSON.stringify({ schemaVersion: 'buildr.local-app-health/v1', status: 'ready' })); }
+      } else { res.end(JSON.stringify({ schemaVersion: 'buildr.local-app-health/v1', status: mode === 'unhealthy' ? 'starting' : 'ready' })); }
     });
     server.listen(0, '127.0.0.1', () => {
       fs.writeFileSync(path.join(process.env.BUILDR_APP_DATA_DIR, 'instance.json'), JSON.stringify({
@@ -113,6 +113,7 @@ else {
     currentProductInvocation() { return { command: process.execPath, argsPrefix: [worker] }; },
     productRoot() { return target; },
     atomicWriteJson(file, value) { fs.writeFileSync(file, JSON.stringify(value)); },
+    removePath(file) { fs.rmSync(file, { force: true }); },
   };
   return { target, dataRoot, pidFile, runtime, start(options = {}) {
     return startPreview(runtime, 'demo', ['--target', target, '--no-open'], { dataRoot, ...options });
@@ -172,5 +173,17 @@ test('preview spawn failure is reported without an unhandled child error', async
     assert.equal(error.details.pid, null);
     return true;
   });
+  assert.equal(readPreviewOwner('demo', fixture.dataRoot), null);
+});
+
+test('preview timeout removes only its exited worker instance record when health never becomes ready', { timeout: 15_000 }, async (t) => {
+  const fixture = startupFixture(t, 'unhealthy');
+  await assert.rejects(fixture.start({ startupTimeoutMs: 3000 }), (error) => {
+    assert.equal(error.code, 'preview_start_timeout');
+    assert.equal(error.details.phase, 'health-not-ready');
+    assertProcessExited(error.details.pid);
+    return true;
+  });
+  assert.equal(fs.existsSync(path.join(previewDataRoot('demo', fixture.dataRoot), 'instance.json')), false);
   assert.equal(readPreviewOwner('demo', fixture.dataRoot), null);
 });

--- a/projects/product/services/buildr/test/integration/preview-ownership.test.mjs
+++ b/projects/product/services/buildr/test/integration/preview-ownership.test.mjs
@@ -3,8 +3,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { execFileSync } from 'node:child_process';
 
-import { assertPreviewStopOwner, previewDataRoot, readPreviewOwner, stopPreview } from '../../src/web/application/preview-lifecycle.mjs';
+import { assertPreviewStopOwner, previewDataRoot, readPreviewOwner, startPreview, stopPreview } from '../../src/web/application/preview-lifecycle.mjs';
 
 const head = 'a'.repeat(40);
 const owner = {
@@ -57,4 +58,119 @@ test('Task preview 可在进程停止后暂留 owner，等待 Environment Receip
 
   await stopPreview(owner.instance, { dataRoot, caller: caller() });
   assert.equal(readPreviewOwner(owner.instance, dataRoot), null);
+});
+
+// Real subprocess + HTTP boundary, with only the Web worker replaced. This keeps
+// startup failure cases deterministic without bootstrapping entire workspaces.
+function startupFixture(t, mode) {
+  const target = fs.mkdtempSync(path.join(os.tmpdir(), 'buildr-preview-start-'));
+  const dataRoot = path.join(target, 'app-data');
+  const worker = path.join(target, 'worker.mjs');
+  const pidFile = path.join(target, 'worker.pid');
+  t.after(async () => {
+    if (fs.existsSync(pidFile)) {
+      const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+      try { process.kill(pid, 'SIGKILL'); } catch (error) { if (error.code !== 'ESRCH') throw error; }
+      for (let attempt = 0; attempt < 100; attempt++) {
+        try { process.kill(pid, 0); } catch { break; }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+    fs.rmSync(target, { recursive: true, force: true });
+  });
+  execFileSync('git', ['init', '--quiet', target]);
+  execFileSync('git', ['-C', target, '-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '--quiet', '--allow-empty', '-m', 'fixture']);
+  fs.writeFileSync(worker, `
+import fs from 'node:fs';
+import path from 'node:path';
+import http from 'node:http';
+fs.writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));
+const mode = ${JSON.stringify(mode)};
+if (mode === 'exit') { console.error('fixture startup failure'); process.exit(23); }
+if (mode === 'hang') { process.on('SIGTERM', () => {}); setInterval(() => {}, 1000); }
+else {
+  setTimeout(() => {
+    const server = http.createServer((req, res) => {
+      if (req.headers['x-buildr-instance'] !== 'fixture-secret') { res.writeHead(403).end(); return; }
+      if (req.method === 'POST') {
+        res.writeHead(202).end();
+        server.close(() => process.exit(0));
+      } else { res.end(JSON.stringify({ schemaVersion: 'buildr.local-app-health/v1', status: 'ready' })); }
+    });
+    server.listen(0, '127.0.0.1', () => {
+      fs.writeFileSync(path.join(process.env.BUILDR_APP_DATA_DIR, 'instance.json'), JSON.stringify({
+        schemaVersion: 'buildr.local-app-instance/v1', pid: process.pid,
+        url: 'http://127.0.0.1:' + server.address().port, secret: 'fixture-secret',
+      }));
+    });
+  }, mode === 'slow' ? 5000 : 0);
+}
+`);
+  const runtime = {
+    assertNoUnknownOptions() {},
+    optionValue(args, key, fallback) { const index = args.indexOf(key); return index < 0 ? fallback : args[index + 1]; },
+    assertInitializedBuildrWorkspace() {},
+    currentProductInvocation() { return { command: process.execPath, argsPrefix: [worker] }; },
+    productRoot() { return target; },
+    atomicWriteJson(file, value) { fs.writeFileSync(file, JSON.stringify(value)); },
+  };
+  return { target, dataRoot, pidFile, runtime, start(options = {}) {
+    return startPreview(runtime, 'demo', ['--target', target, '--no-open'], { dataRoot, ...options });
+  } };
+}
+
+function assertProcessExited(pid) {
+  assert.throws(() => process.kill(pid, 0), (error) => error.code === 'ESRCH');
+}
+
+test('preview waits for a healthy slow worker beyond the former four-second polling window', { timeout: 20_000 }, async (t) => {
+  const fixture = startupFixture(t, 'slow');
+  const result = await fixture.start();
+  assert.equal(result.status, 'started');
+  assert.equal(result.pid, Number(fs.readFileSync(fixture.pidFile, 'utf8')));
+  const reused = await fixture.start();
+  assert.equal(reused.status, 'reused');
+  assert.equal(reused.pid, result.pid);
+  await stopPreview('demo', { dataRoot: fixture.dataRoot });
+});
+
+test('preview reports early worker exit and preserves its diagnostic log', async (t) => {
+  const fixture = startupFixture(t, 'exit');
+  await assert.rejects(fixture.start(), (error) => {
+    assert.equal(error.code, 'preview_start_failed');
+    assert.equal(error.details.exitCode, 23);
+    assert.match(error.details.diagnostic, /fixture startup failure/);
+    assert.match(fs.readFileSync(error.details.logFile, 'utf8'), /fixture startup failure/);
+    assertProcessExited(error.details.pid);
+    return true;
+  });
+  assert.equal(readPreviewOwner('demo', fixture.dataRoot), null);
+});
+
+test('preview timeout reclaims its worker even when SIGTERM is ignored and leaves a peer intact', { timeout: 20_000 }, async (t) => {
+  const peer = startupFixture(t, 'ready');
+  const peerResult = await peer.start();
+  const fixture = startupFixture(t, 'hang');
+  await assert.rejects(fixture.start({ startupTimeoutMs: 3000 }), (error) => {
+    assert.equal(error.code, 'preview_start_timeout');
+    assert.equal(error.details.phase, 'instance-missing');
+    assert.equal(error.details.cleanup, 'terminated');
+    assertProcessExited(error.details.pid);
+    return true;
+  });
+  assert.equal(readPreviewOwner('demo', fixture.dataRoot), null);
+  assert.equal((await peer.start()).pid, peerResult.pid);
+  await stopPreview('demo', { dataRoot: peer.dataRoot });
+});
+
+test('preview spawn failure is reported without an unhandled child error', async (t) => {
+  const fixture = startupFixture(t, 'ready');
+  fixture.runtime.currentProductInvocation = () => ({ command: path.join(fixture.target, 'missing-executable'), argsPrefix: [] });
+  await assert.rejects(fixture.start(), (error) => {
+    assert.equal(error.code, 'preview_start_failed');
+    assert.match(error.message, /ENOENT/);
+    assert.equal(error.details.pid, null);
+    return true;
+  });
+  assert.equal(readPreviewOwner('demo', fixture.dataRoot), null);
 });

--- a/projects/product/services/buildr/test/system/verification-changed-paths.test.mjs
+++ b/projects/product/services/buildr/test/system/verification-changed-paths.test.mjs
@@ -4,7 +4,26 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import { collectChangedProductPaths, resolveVerificationBase } from '../../test/verification/changed-paths.mjs';
+
+test('依赖安装前可加载 changed path collector，缺少 YAML 时保守处理声明变化', () => {
+  const moduleUrl = pathToFileURL(path.resolve(import.meta.dirname, '../verification/changed-paths.mjs')).href;
+  const script = `
+    import assert from 'node:assert/strict';
+    import { registerHooks } from 'node:module';
+    registerHooks({ resolve(specifier, context, nextResolve) {
+      if (specifier === 'yaml') throw Object.assign(new Error('yaml is not installed'), { code: 'ERR_MODULE_NOT_FOUND' });
+      return nextResolve(specifier, context);
+    } });
+    const collector = await import(${JSON.stringify(moduleUrl)});
+    assert.deepEqual(collector.collectChangedProductPaths({ productRoot: process.cwd(), explicitPaths: ['docs/a.md'] }).paths, ['docs/a.md']);
+    assert.equal(collector.isVersionOnlyPackageMetadataChange('package.json', '{"version":"1.0.0"}', '{"version":"1.0.1"}'), true);
+    assert.equal(collector.isVerificationDeclarationMetadataOnlyChange('capabilities: []', 'capabilities: []'), false);
+    process.stdout.write('ready');
+  `;
+  assert.equal(execFileSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8' }), 'ready');
+});
 
 function git(root, args) {
   return execFileSync('git', args, { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });

--- a/projects/product/services/buildr/test/system/worktree-create.test.mjs
+++ b/projects/product/services/buildr/test/system/worktree-create.test.mjs
@@ -356,17 +356,23 @@ test('多独立仓库在部分集成时保全全部工作树，完整保留后�
     command(repo.checkoutPath, 'git', ['commit', '-m', 'result']);
   }
   command(root, 'git', ['merge', '--ff-only', 'codex/multi-closeout']);
+  // Git may check out CRLF on Windows. Cleanup must preserve the actual bytes,
+  // while a separate assertion independently verifies the delivered content.
+  const workspaceResult = fs.readFileSync(path.join(root, 'result.txt'));
+  assert.equal(workspaceResult.toString('utf8').replace(/\r\n/g, '\n'), 'workspace\n');
   const partial = provider.cleanupGitWorktrees({ workspaceRoot: root, taskId, allowCompleted: true });
   assert.equal(partial.status, 'blocked');
   assert.equal(partial.diagnostic.code, 'git_worktree_not_integrated');
   assert.equal(partial.effects.length, 0);
   for (const repo of prepared.repositories) assert.equal(fs.existsSync(path.join(repo.checkoutPath, 'result.txt')), true);
   command(service, 'git', ['merge', '--ff-only', 'codex/multi-closeout']);
+  const serviceResult = fs.readFileSync(path.join(service, 'result.txt'));
+  assert.equal(serviceResult.toString('utf8').replace(/\r\n/g, '\n'), 'service:demo/api\n');
   const completed = provider.cleanupGitWorktrees({ workspaceRoot: root, taskId, allowCompleted: true });
   assert.equal(completed.status, 'cleaned', JSON.stringify(completed));
   assert.equal(fs.existsSync(prepared.repositories[0].checkoutPath), false);
-  assert.equal(fs.readFileSync(path.join(root, 'result.txt'), 'utf8'), 'workspace\n');
-  assert.equal(fs.readFileSync(path.join(service, 'result.txt'), 'utf8'), 'service:demo/api\n');
+  assert.deepEqual(fs.readFileSync(path.join(root, 'result.txt')), workspaceResult);
+  assert.deepEqual(fs.readFileSync(path.join(service, 'result.txt')), serviceResult);
 });
 
 test('已核验不同提交编号的交付可由环境CLI清理，错误输入和新内容仍保全', (t) => {

--- a/projects/product/services/buildr/test/verification/changed-paths.mjs
+++ b/projects/product/services/buildr/test/verification/changed-paths.mjs
@@ -2,10 +2,12 @@ import path from 'node:path';
 import fs from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { isDeepStrictEqual } from 'node:util';
-import YAML from 'yaml';
+import { createRequire } from 'node:module';
 import { normalizeProductPath } from './planner.mjs';
 import { VERIFICATION_GOVERNED_REPOSITORY_INPUTS } from './ownership.mjs';
 import { sameFilesystemPath } from '../../src/infrastructure/git/checkout-identity.mjs';
+
+const require = createRequire(import.meta.url);
 
 function git(gitRoot, args, options = {}) {
   return execFileSync('git', args, { cwd: gitRoot, encoding: options.encoding ?? 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
@@ -61,6 +63,9 @@ export function isSelectionOnlyPackageMetadataChange(productPath, baseText, curr
 }
 
 function withoutVerificationPresentationFields(text) {
+  // CI plans run before npm ci. Missing YAML keeps the declaration change
+  // conservative through isVerificationDeclarationMetadataOnlyChange's catch.
+  const YAML = require('yaml');
   const value = YAML.parse(text);
   if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('verification.yml must contain a mapping');
   for (const resource of value.resources ?? []) delete resource.title;

--- a/projects/product/services/buildr/test/verification/concurrency/task-acceptance.mjs
+++ b/projects/product/services/buildr/test/verification/concurrency/task-acceptance.mjs
@@ -191,13 +191,14 @@ try {
     fs.writeFileSync(planPath, `${JSON.stringify(plan, null, 2)}\n`);
     return planPath;
   });
+  // 外层等待覆盖环境核验、能力执行和证据落盘，不把托管机器的启动延迟误判为业务失败。
   const verificationProcesses = summary.tasks.map((task) => spawnSupervised(task.cliInvocation.command, [
     ...task.cliInvocation.argsPrefix,
     'verification', 'run', '--project', 'nested', '--plan', verificationPlans[summary.tasks.indexOf(task)],
     '--target-identity', digest(`target:${task.taskId}`), '--target', task.environmentRoot,
     '--candidate-identity', digest(`candidate:${task.taskId}`), '--candidate-generation', '1',
     '--environment', task.taskId, '--workspace', workspace, '--detail', 'full', '--json',
-  ], { cwd: task.repositories[1].checkoutPath, env, owner: { taskId: task.taskId, runId: 'formal-verification' }, timeoutMs: platformTimeout(15_000), outputLimit: 64 * 1024 }));
+  ], { cwd: task.repositories[1].checkoutPath, env, owner: { taskId: task.taskId, runId: 'formal-verification' }, timeoutMs: platformTimeout(60_000), outputLimit: 64 * 1024 }));
   const verificationResults = await Promise.all(verificationProcesses.map((run) => run.completed));
   assert.equal(processesOverlap(verificationResults[0], verificationResults[1]), true);
   summary.verificationRuns = verificationResults.map((result, index) => {

--- a/projects/product/services/buildr/test/verification/runtime/adapter-parity.mjs
+++ b/projects/product/services/buildr/test/verification/runtime/adapter-parity.mjs
@@ -164,16 +164,15 @@ async function verifyLifecycle(context) {
 
   if (adapterId === 'codex' || adapterId === 'claude-code') {
     const renderedFinish = fs.readFileSync(path.join(runtimeRoot, 'skills', 'task-finish', 'SKILL.md'), 'utf8');
-    assert.ok(renderedFinish.includes('preflight → prepare → verify → deliver → cleanup'));
-    assert.ok(renderedFinish.includes('完整“收尾/交付”意图'));
-    assert.ok(renderedFinish.includes('正式 Task 路径'));
-    assert.ok(renderedFinish.includes('普通 Git 路径'));
-    assert.ok(renderedFinish.includes('buildr task next'));
-    assert.ok(renderedFinish.includes('task finish reconcile'));
-    assert.ok(renderedFinish.includes('不接受调用方声明成功或自制证明'));
-    assert.ok(renderedFinish.includes('只有交付决定任务贡献是否进入目标远端'));
-    assert.ok(renderedFinish.includes('其他结果失败形成 attention，不撤销已确认交付'));
-    assert.ok(renderedFinish.includes('不产生正式生命周期证据'));
+    assert.ok(renderedFinish.includes('已有任务结果登记'));
+    assert.ok(renderedFinish.includes('task complete --expected-record <recordDigest>'));
+    assert.ok(renderedFinish.includes('没有匹配任务就继续实际工作，不补建记录'));
+    assert.ok(renderedFinish.includes('不重新交付已成立的成果'));
+    assert.ok(renderedFinish.includes('--expected-source'));
+    assert.ok(renderedFinish.includes('--delivered-ref'));
+    assert.ok(renderedFinish.includes('不建立候选、研发交接、旧收尾运行'));
+    assert.ok(!renderedFinish.includes('preflight → prepare → verify → deliver → cleanup'));
+    assert.ok(!renderedFinish.includes('task finish reconcile'));
     assert.ok(!renderedFinish.includes('buildr:contribution openspec#pre-spec-sync'));
   }
 


### PR DESCRIPTION
rc.29 验证失败暴露了退役断言、干净环境计划入口和预览启动失败处理的问题。本请求保留前面的入口修复，并修复预览模块的实际缺陷。

预览启动原先只轮询 80 次，基础等待约 4 秒；超时后抛错但留下子进程。现在使用 10 秒启动期限并持续检查健康状态和子进程退出；提前退出或无法创建进程时立即失败；超时则回收本次创建的子进程，必要时升级终止信号。错误保留进程号、阶段、耗时、退出原因、回收结果和日志。不会按陈旧进程文件猜测需要终止的进程。

预览测试改为先停止进程、再删除临时目录，并在发起启动前登记待清理实例。未删除既有行为断言，也未进一步统一加长测试时限。

验证：新增真实子进程及 HTTP 回归用例，覆盖慢启动、提前退出、超时回收、其他预览不受影响和进程创建失败。本机 7 项通过，约 14 秒；同样的 4 个新增用例放回旧实现全部失败。另修复工作树清理测试对 LF 的硬编码：先验证交付文本，再逐字节比较清理前后的真实文件。旧断言在 core.autocrlf=true 下可稳定复现失败；修复在 LF 和 CRLF 两种配置下均通过。新增实例状态删除复用现有 runtime.removePath，受管写入检查已通过。

最终提交 744713f1：本机完整 51 项核心检查与浏览器正式验证全部通过，耗时约 6 分 58 秒；GitHub 33383171000 的 macOS、Windows 和浏览器检查全部通过。正式任务结果与该提交内容绑定。

保留风险：前一提交的 GitHub 并发停止检查曾出现空诊断失败，最终提交同项通过，但尚未证实该历史偶发原因；不宣称已消除所有测试偶发问题。上述检查不等于纳入修复后的发布候选与发布包验证。

此前入口修复还包括退役父协调断言、YAML 按需加载、当前 Finish 文本断言、macOS 使用已有 ci 配置及应用进程测试外层等待修正。

不包含发布副作用。需按 dev 分支审查规则批准后集成，再为纳入修复后的发布来源生成新的候选验证与唯一发布包；旧失败的候选结果不能复用。
