### PR TITLE
fix(package): 修复发布包旧任务契约校验

### DIFF
--- a/projects/product/services/buildr/src/agent-assets/application/package-maintenance/static-validation.mjs
+++ b/projects/product/services/buildr/src/agent-assets/application/package-maintenance/static-validation.mjs
@@ -1,6 +1,18 @@
 import { capabilityKey, parseCapabilityContract, validateCapabilityIdentity } from '../../infrastructure/runtime/skills/manifests.mjs';
 import { REQUIRED_INTERNAL_WORKFLOW_ROUTES } from '../../../task/contracts/internal-workflow-route-catalog.mjs';
 
+// Validate the advertised command contract, not prose or placeholder spelling.
+export function validateTaskRecordSkillCommands(content) {
+  const problems = [];
+  for (const action of ['create', 'inspect', 'update', 'activate', 'complete', 'abandon']) {
+    if (!new RegExp(`\\bbuildr\\s+task\\s+${action}\\b`).test(content)) {
+      problems.push(`task-manager Skill must document "buildr task ${action}".`);
+    }
+  }
+  if (!content.includes('--expected-record')) problems.push('task-manager Skill must document --expected-record for version-checked mutations.');
+  return problems;
+}
+
 export function createPackageStaticValidator(deps) {
   const {
     GENERATED_USER_REGISTRY_RESOURCE_SOURCES,
@@ -1056,21 +1068,7 @@ export function createPackageStaticValidator(deps) {
         }
       }
       if (skill.id === 'task-manager') {
-        for (const requiredText of [
-          '本 Skill 是 `buildr.task-record/v2` 的默认 provider',
-          '`todo` 是已接受但未启动的 data-only 意向',
-          'buildr task activate <task-id>',
-          '--retrospective-source <task-id>',
-          '普通任务分流',
-          '不要仅因用户说“任务”就触发',
-          '不读取 environment receipt',
-          '不从 worktree 推断 retained root',
-          'Buildr Web 是同一 Application 的独立人类客户端',
-          '不直接读写 Workspace SQLite 或旧 `.buildr/tasks/<task-id>/task.yml`',
-          '不自动 commit、push、publication、Finish 或 cleanup',
-        ]) {
-          if (!skillContent.includes(requiredText)) problems.push(`task-manager Skill must include ${JSON.stringify(requiredText)}.`);
-        }
+        problems.push(...validateTaskRecordSkillCommands(skillContent));
         for (const forbiddenText of ['buildr worktree create', 'buildr verification run', 'buildr task finish run', 'git commit', 'git push']) {
           if (skillContent.includes(forbiddenText)) problems.push(`task-manager Skill must not execute professional action ${JSON.stringify(forbiddenText)}.`);
         }
@@ -1263,7 +1261,7 @@ export function createPackageStaticValidator(deps) {
         if (!(skill.requires || []).some((item) => item.capability === 'buildr.task-record' && item.version === 2 && item.mode === 'required')) problems.push('task-retrospective must require buildr.task-record@2.');
       }
       if (skill.id === 'task-triage') {
-        for (const requiredText of ['## 2. 两轴决策', '`code-only`', '`spec-maintenance`', '`change-flow`', '`blocked`', 'Repository set', '`implementation`', '`metadata-only`', '`unknown`', '`buildr.task-record/v2`', '待办意向', 'todo create', 'Formal Task Record本身不是编辑、构建或有界测试的通用工作许可', '首次受管效果前取得`ready`', '`buildr.git-operations/v1`', '从 Parent 规划项启动独立 Child Task', '初始不引用Parent Change', 'Child execution root中创建该独立目标自己的窄Change', '新正式 Task 创建前收敛逐 repository 权威基线', '`fetch` operation', '`rebase` operation', '`rebase --abort`', 'Git 基线：converged / none / blocked', '`buildr.current-knowledge-maintenance/v2`', '`buildr.task-environment/v1`', '`maintain`', '`change-required`', 'provider 不 ready', 'selected `buildr.task-development/v2` provider', 'selected `buildr.task-verification/v3` provider', '不预设 minimal/affected/candidate 层级', '## 4. 输出契约']) {
+        for (const requiredText of ['## 2. 两轴决策', '`code-only`', '`spec-maintenance`', '`change-flow`', '`blocked`', 'Repository set', '`implementation`', '`metadata-only`', '`unknown`', '`buildr.task-record/v2`', '待办意向', 'todo create', 'Formal Task Record本身不是编辑、构建或有界测试的通用工作许可', '首次受管效果前取得`ready`', '`buildr.git-operations/v1`', '新正式 Task 创建前收敛逐 repository 权威基线', '`fetch` operation', '`rebase` operation', '`rebase --abort`', 'Git 基线：converged / none / blocked', '`buildr.current-knowledge-maintenance/v2`', '`buildr.task-environment/v1`', '`maintain`', '`change-required`', 'provider 不 ready', 'selected `buildr.task-development/v2` provider', 'selected `buildr.task-verification/v3` provider', '不预设 minimal/affected/candidate 层级', '## 4. 输出契约']) {
           if (!skillContent.includes(requiredText)) problems.push(`task-triage Skill must include ${JSON.stringify(requiredText)}.`);
         }
         if (!(skill.requires || []).some((item) => item.capability === 'buildr.task-record' && item.version === 2 && item.mode === 'optional')) problems.push('task-triage must optionally require buildr.task-record@2.');

--- a/projects/product/services/buildr/test/unit/package-task-skill.test.mjs
+++ b/projects/product/services/buildr/test/unit/package-task-skill.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { validateTaskRecordSkillCommands } from '../../src/agent-assets/application/package-maintenance/static-validation.mjs';
+
+const content = `说明文字不构成命令契约。
+buildr task create <id>
+buildr task inspect <id>
+buildr task update <id> --expected-record <recordDigest>
+buildr task activate <id>
+buildr task complete <id> --expected-record <recordDigest>
+buildr task abandon <id>
+`;
+
+test('任务包契约接受不改变命令的文案和占位符变化', () => {
+  assert.deepEqual(validateTaskRecordSkillCommands(content), []);
+  const rewritten = content.replaceAll('<id>', '<task-id>').replaceAll('buildr task ', 'buildr  task  ').replaceAll('任务记录', '任务业务记录');
+  assert.deepEqual(validateTaskRecordSkillCommands(rewritten), []);
+});
+
+test('任务包契约仍拒绝缺失公开操作或版本核对参数', () => {
+  for (const action of ['create', 'inspect', 'update', 'activate', 'complete', 'abandon']) {
+    const missing = content.replaceAll(`buildr task ${action}`, `buildr task removed-${action}`);
+    assert.ok(validateTaskRecordSkillCommands(missing).some((problem) => problem.includes(`buildr task ${action}`)));
+  }
+  assert.ok(validateTaskRecordSkillCommands(content.replaceAll('--expected-record', '--removed-record')).some((problem) => problem.includes('--expected-record')));
+});


### PR DESCRIPTION
发布候选运行 33385955282 在 package-static 失败：校验器仍要求 task-manager 和 task-triage 技能包含已经退役的固定句子，导致当前合法任务技能不能打包。

本改动仅修复校验器与回归测试：任务管理技能改为检查六个公开任务命令和版本核对参数 --expected-record，保留能力版本、禁止专业动作和通用发布校验；移除任务分流技能中三个退役父子流程文案要求。不修改任务技能本身或放宽任务操作权限。

验证：新增纯函数回归覆盖文案/占位符变化可接受、缺失命令/参数仍拒绝。本机完整 preflight-macos 14 项通过；受影响正式验证和 GitHub 检查运行中。

合入后将以来源标记纳入 rc.29 原发布集合，重新形成匹配发布来源的候选与发布包。没有 tag/npm/GitHub Release 副作用。
