### PR TITLE
fix(release): 修复发布与任务环境收尾交接

### DIFF
--- a/projects/product/services/buildr/src/task/application/task-environment-application.mjs
+++ b/projects/product/services/buildr/src/task/application/task-environment-application.mjs
@@ -1281,7 +1281,8 @@ export function registerTaskEnvironmentApplication(runtime) {
       const completed = persistedAuthorization?.type === 'completed' && authorization === persistedAuthorization;
       if (!abandon && !finish && !noChange && !completed) throw taskEnvironmentError('task_environment_cleanup_unauthorized', 'Environment cleanup 需要已完成或明确放弃的任务；具体删除安全仍由资源所有者复核。', 409, undefined, '先完成并对账交付、确认 Task 无代码变更，或明确 abandon Task。');
       const reviewedDelivery = normalizeTaskCleanupDelivery(cleanupDelivery, persistence.receipt.scopes.filter((scope) => scope.provider?.capability === GIT_PROVIDER).map((scope) => scope.selector));
-      if (Object.keys(reviewedDelivery).length && !completed) throw taskEnvironmentError('task_environment_cleanup_unauthorized', '已核验交付输入只用于已完成且有成果交付的任务。', 409);
+      const hasReviewedDelivery = Object.keys(reviewedDelivery).length > 0;
+      if (hasReviewedDelivery && !completed && !noChange) throw taskEnvironmentError('task_environment_cleanup_unauthorized', '已核验交付输入只用于已完成任务。', 409);
       cleanupAuthorized = true;
       assertEnvironmentManager(root, persistence.receipt);
       managerAuthorized = true;
@@ -1300,7 +1301,7 @@ export function registerTaskEnvironmentApplication(runtime) {
       }
       const hasGit = persistence.receipt.scopes.some((scope) => scope.provider?.capability === GIT_PROVIDER);
       if (hasGit) {
-        const provider = runtime.cleanupGitWorktrees({ workspaceRoot: root, taskId, integratedRefs: finish ? authorization.deliveries : {}, integratedContributions: finish ? authorization.integratedContributions || {} : {}, allowDirty: abandon, allowNoChange: noChange, allowCompleted: completed, cleanupDelivery });
+        const provider = runtime.cleanupGitWorktrees({ workspaceRoot: root, taskId, integratedRefs: finish ? authorization.deliveries : {}, integratedContributions: finish ? authorization.integratedContributions || {} : {}, allowDirty: abandon, allowNoChange: noChange && !hasReviewedDelivery, allowCompleted: completed || (noChange && hasReviewedDelivery), cleanupDelivery });
         effects.push(...provider.effects.map((effect) => ({ ...effect, provider: GIT_PROVIDER })));
         if (provider.status === 'blocked') throw taskEnvironmentError(provider.diagnostic?.code || 'task_environment_provider_cleanup_blocked', provider.diagnostic?.message || 'Git provider cleanup blocked.', 409, provider.diagnostic);
       }
@@ -1310,7 +1311,7 @@ export function registerTaskEnvironmentApplication(runtime) {
       }
       const completedAt = now();
       const retainedSummary = retainedSharedScopes.length ? `共享执行根已保留（${retainedSharedScopes.map((scope) => scope.selector).join('、')}），仅解除 Environment 占用。` : '';
-      const summary = `${abandon ? '明确放弃授权下，已清理可证明属于该 Task 的环境资源。' : noChange ? 'Task 已确认无代码变更，环境资源已在无 HEAD 漂移证明下清理。' : '任务环境资源已按当前内容保全事实清理或保留；本结果不证明远端交付。'}${retainedSummary}`;
+      const summary = `${abandon ? '明确放弃授权下，已清理可证明属于该 Task 的环境资源。' : noChange && !hasReviewedDelivery ? 'Task 已确认无代码变更，环境资源已在无 HEAD 漂移证明下清理。' : '任务环境资源已按当前内容保全事实清理或保留；本结果不证明远端交付。'}${retainedSummary}`;
       persistence = runtime.writeTaskEnvironmentPersistence(root, { ...persistence.receipt, status: 'cleaned', resources: persistence.receipt.resources.map((item) => ({ ...item, status: 'released', updatedAt: completedAt })), latest: { ...persistence.receipt.latest, cleanup: { status: 'cleaned', completedAt, summary } }, updatedAt: completedAt });
       effects.push({ type: 'receipt-finalized', path: persistence.file });
       let maintenanceRefresh = null;

--- a/projects/product/services/buildr/src/task/infrastructure/git-worktree-provider.mjs
+++ b/projects/product/services/buildr/src/task/infrastructure/git-worktree-provider.mjs
@@ -93,6 +93,13 @@ export function registerGitWorktreeProvider(runtime) {
     return { repository: path.resolve(root.stdout.trim()), branch: branch.stdout.trim(), head: head.stdout.trim(), clean: status.stdout.trim() === '', registered };
   }
 
+  function retainedDeliveryRefs(repository, targetHead, taskBranch) {
+    const result = git(repository, ['for-each-ref', '--contains', targetHead, '--format=%(refname)', 'refs/heads', 'refs/remotes']);
+    if (result.status !== 0) return null;
+    const excluded = new Set([`refs/heads/${taskBranch}`, `refs/remotes/origin/${taskBranch}`]);
+    return result.stdout.split(/\r?\n/u).map((item) => item.trim()).filter((item) => item && !excluded.has(item)).sort();
+  }
+
   function sharedGitDir(repository) {
     const value = gitText(repository, ['rev-parse', '--git-common-dir']);
     if (!value) throw new Error(`Unable to resolve shared Git metadata: ${repository}`);
@@ -382,7 +389,12 @@ export function registerGitWorktreeProvider(runtime) {
         // Capture the retained target for deletion-time version checks.
         // With reviewed input the caller, not this provider, owns delivery assessment.
         let retainedRef = null;
-        if (allowCompleted) {
+        if (reviewedDelivery) {
+          const refs = retainedDeliveryRefs(record.sourceRepository, reviewedDelivery.targetHead, record.branch);
+          if (!refs?.length) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_delivery_target_mismatch', message: `已核验的交付提交没有由非任务分支持有：${record.selector}。` });
+          retainedRef = reviewedDelivery.targetHead;
+          retainedTargets.set(record.selector, { kind: 'refs', targetHead: reviewedDelivery.targetHead, refs });
+        } else if (allowCompleted) {
           const retained = worktreeIdentity(record.sourceRepository);
           if (!retained || retained.branch === record.branch || !retained.branch) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_retained_target_unavailable', message: `Retained repository needs a non-task branch: ${record.selector}.` }, ['保留工作树，先确认承载成果的保留分支。']);
           retainedRef = retained.head;
@@ -390,7 +402,7 @@ export function registerGitWorktreeProvider(runtime) {
         }
         if (reviewedDelivery) {
           const delivered = gitText(record.sourceRepository, ['rev-parse', '--verify', `${reviewedDelivery.targetHead}^{commit}`]);
-          if (delivered !== reviewedDelivery.targetHead || !retainedRef || git(record.sourceRepository, ['merge-base', '--is-ancestor', delivered, retainedRef]).status !== 0) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_delivery_target_mismatch', message: `已核验的交付提交不由当前保留分支持有：${record.selector}。` });
+          if (delivered !== reviewedDelivery.targetHead || !retainedRef) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_delivery_target_mismatch', message: `已核验的交付提交不由当前保留分支持有：${record.selector}。` });
         }
         const integratedRef = allowNoChange ? record.head : retainedRef || integratedRefs[record.selector] || null;
         const contributionProof = reviewedDelivery ? null : integratedContributions[record.selector] || null;
@@ -420,8 +432,13 @@ export function registerGitWorktreeProvider(runtime) {
       for (const record of [...checks].sort((left, right) => right.checkoutPath.split(path.sep).length - left.checkoutPath.split(path.sep).length)) {
         const retainedTarget = retainedTargets.get(record.selector);
         if (retainedTarget) {
-          const currentTarget = worktreeIdentity(record.sourceRepository);
-          if (!currentTarget || currentTarget.branch !== retainedTarget.branch || currentTarget.head !== retainedTarget.head) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_retained_target_drift', message: `Retained repository changed before cleanup: ${record.selector}.` }, ['重新核对保留分支和内容包含关系后重试。']);
+          if (retainedTarget.kind === 'refs') {
+            const currentRefs = retainedDeliveryRefs(record.sourceRepository, retainedTarget.targetHead, record.branch);
+            if (!currentRefs || !retainedTarget.refs.some((ref) => currentRefs.includes(ref))) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_retained_target_drift', message: `Delivered target lost its retained ref before cleanup: ${record.selector}.` }, ['重新核对保留引用后重试。']);
+          } else {
+            const currentTarget = worktreeIdentity(record.sourceRepository);
+            if (!currentTarget || currentTarget.branch !== retainedTarget.branch || currentTarget.head !== retainedTarget.head) return result('cleanup', 'blocked', taskId, stored.file, checks, effects, { code: 'git_worktree_retained_target_drift', message: `Retained repository changed before cleanup: ${record.selector}.` }, ['重新核对保留分支和内容包含关系后重试。']);
+          }
         }
         if (record.reviewedDelivery && record.checkoutExists) {
           const currentSource = worktreeIdentity(record.checkoutPath);

--- a/projects/product/services/buildr/test/integration-candidate-release/release-git-convergence.test.mjs
+++ b/projects/product/services/buildr/test/integration-candidate-release/release-git-convergence.test.mjs
@@ -23,6 +23,7 @@ import {
 } from '../../tools/release/release-selection.mjs';
 import { createReleaseTransactionEvidence } from '../../tools/release/release-transaction-evidence.mjs';
 import { createReleaseExecutionBinding } from '../../tools/release/release-execution-binding.mjs';
+import { runReleaseOrchestration } from '../../tools/release/release-orchestration-runner.mjs';
 
 const digest = (value) => `sha256-${String(value).padStart(64, '0')}`;
 
@@ -61,7 +62,7 @@ function releaseWorktree(root, remote, baseline, version = '0.1.0-rc.5') {
   fs.writeFileSync(providerEvidence, JSON.stringify({ schemaVersion: 'buildr.git-worktree-evidence/v1', taskId: `release-${version}`, workspaceRoot: controller, branch: `codex/release-${version}`, planDigest: digest('1'), status: 'ready', repositories: [{ selector: 'workspace', checkoutPath: work, branch: `codex/release-${version}` }], effects: [], updatedAt: '2026-08-28T00:00:00.000Z' }));
   const task = { taskId: `release-${version}`, status: 'active' };
   const environmentResult = { status: 'ready', taskId: task.taskId, environment: { workspace: { root: controller }, controller: { identity: digest('2') }, runtimeInvocation: { identity: `${digest('3')}:v24.15.0` }, scopes: [{ selector: 'workspace', executionRoot: work, provider: { evidence: providerEvidence } }] } };
-  return { work, binding: () => createReleaseExecutionBinding({ version, task, environmentResult, repo: work }) };
+  return { controller, work, binding: () => createReleaseExecutionBinding({ version, task, environmentResult, repo: work }) };
 }
 
 function convergenceFixture() {
@@ -136,7 +137,7 @@ function convergenceFixture() {
       registrySmoke: 'passed',
     },
   });
-  return { root, remote, seed, work: release.work, binding: release.binding, base, selected, frozen, releaseCommit, releaseTree, mainCommit, devCommit, publicationEvidence };
+  return { root, remote, seed, controller: release.controller, work: release.work, binding: release.binding, base, selected, frozen, releaseCommit, releaseTree, mainCommit, devCommit, publicationEvidence };
 }
 
 test('release→main creates one PR from the frozen release source after explicit authorization', (t) => {
@@ -326,7 +327,7 @@ test('黄金生命周期以同一active Task等待授权并在零中间资源clo
     expectedCommit: data.releaseCommit,
     authorizeCarrierCleanup: true,
     authorizeLocalSelectionCleanup: true,
-    executionBinding: data.binding(),
+    publicationEvidence: data.publicationEvidence,
   });
   assert.equal(unknown.status, 'blocked');
   assert.equal(unknown.diagnostic.code, 'release-closeout-identity-unknown');
@@ -340,7 +341,7 @@ test('黄金生命周期以同一active Task等待授权并在零中间资源clo
     expectedCommit: data.releaseCommit,
     authorizeCarrierCleanup: true,
     authorizeLocalSelectionCleanup: true,
-    executionBinding: data.binding(),
+    publicationEvidence: data.publicationEvidence,
   });
   assert.equal(first.status, 'passed', JSON.stringify(first));
   assert.equal(first.formalReleaseRef.disposition, 'retained-and-verified');
@@ -353,7 +354,7 @@ test('黄金生命周期以同一active Task等待授权并在零中间资源clo
     expectedCommit: data.releaseCommit,
     authorizeCarrierCleanup: true,
     authorizeLocalSelectionCleanup: true,
-    executionBinding: data.binding(),
+    publicationEvidence: data.publicationEvidence,
   });
   assert.equal(second.status, 'passed', JSON.stringify(second));
   assert.equal(second.action, 'already-cleaned');
@@ -371,6 +372,71 @@ test('黄金生命周期以同一active Task等待授权并在零中间资源clo
   assert.equal(closed.status, 'passed');
   assert.equal(closed.phase, 'closed');
   assert.equal(closed.releaseTask.taskId, waiting.releaseTask.taskId);
+});
+
+test('发布编排真实调用Git closeout并把精确交付映射交给Environment owner', async (t) => {
+  const data = convergenceFixture();
+  t.after(() => fs.rmSync(data.root, { recursive: true, force: true }));
+  const version = '0.1.0-rc.5';
+  const taskId = `release-${version}`;
+  const carrier = releaseCarrierBranchFor(version, data.frozen.generation);
+  git(data.controller, 'branch', carrier, data.releaseCommit);
+  git(data.controller, 'push', 'origin', `${carrier}:${carrier}`);
+  let task = { taskId, status: 'active', result: null };
+  let environmentStatus = 'ready';
+  const controllerCalls = [];
+  const orchestrationContext = createReleaseContext({
+    selection: data.publicationEvidence.context.selection,
+    release: data.publicationEvidence.context.release,
+    candidate: { status: 'passed', runId: 42, runAttempt: 1, aggregateIdentity: digest('4') },
+    convergence: data.publicationEvidence.context.convergence,
+  });
+  const orchestrationEvidence = createReleaseTransactionEvidence({
+    context: orchestrationContext,
+    publish: data.publicationEvidence.publish,
+    outcome: 'passed',
+    publicFacts: {
+      version,
+      tagCommit: data.publicationEvidence.release.tagCommit,
+      npmDistTag: data.publicationEvidence.release.npmDistTag,
+      registryPublished: true,
+      registryIntegrity: data.publicationEvidence.release.registryIntegrity,
+      githubRelease: data.publicationEvidence.release.githubRelease,
+      registrySmoke: 'passed',
+    },
+  });
+  const dependencies = {
+    inspectHostedReleaseTransaction: async () => ({ status: 'passed', evidence: orchestrationEvidence }),
+    reconcilePublishedReleaseWithDev: () => ({ status: 'passed', identity: digest('9'), recoveryIdentity: digest('8'), effects: [], nextActions: [] }),
+    inspectTaskRecord: () => ({ record: task, recordDigest: digest(task.status === 'active' ? '7' : '6') }),
+    inspectTaskEnvironment: () => ({ status: environmentStatus, environment: { workspace: { root: data.controller }, controller: { sourceRoot: path.join(data.controller, 'projects/product/services/buildr'), identity: digest('5') }, runtimeInvocation: { executable: process.execPath } } }),
+    resolveRetainedController: () => ({ executable: process.execPath, argsPrefix: [], workspaceRoot: data.controller }),
+    invokeRetainedController: (_controller, args) => {
+      controllerCalls.push(args);
+      if (args[0] === 'task' && args[1] === 'complete') {
+        task = { ...task, status: 'completed', result: { summary: 'closed', noChange: true } };
+        return { status: 'completed', effects: [{ type: 'task-completed' }] };
+      }
+      if (args[0] === 'task' && args[1] === 'environment') {
+        environmentStatus = 'cleaned';
+        return { status: 'cleaned', effects: [{ type: 'environment-cleaned' }] };
+      }
+      return { status: 'ready', effects: [] };
+    },
+  };
+  const options = {
+    action: 'closeout', version, releaseTask: taskId, publishRunId: 42,
+    repo: data.controller, canonicalWorkspace: data.controller,
+    authorizeCarrierCleanup: true, authorizeLocalSelectionCleanup: true,
+  };
+  const closed = await runReleaseOrchestration(options, dependencies);
+  assert.equal(closed.status, 'passed', JSON.stringify(closed));
+  assert.equal(git(data.controller, 'ls-remote', 'origin', `refs/heads/${carrier}`), '');
+  assert.equal(git(data.controller, 'ls-remote', 'origin', `refs/heads/release-${version}`).startsWith(data.releaseCommit), true);
+  assert.deepEqual(controllerCalls[1].slice(4, 8), ['--expected-source', `workspace=${data.releaseCommit}`, '--delivered-ref', `workspace=${data.mainCommit}`]);
+  const repeated = await runReleaseOrchestration(options, dependencies);
+  assert.equal(repeated.status, 'passed', JSON.stringify(repeated));
+  assert.equal(controllerCalls.filter((args) => args[0] === 'task' && args[1] === 'complete').length, 1);
 });
 
 test('remote release branch cleanup展示精确公开事实并要求独立授权', (t) => {

--- a/projects/product/services/buildr/test/integration-candidate-release/release-orchestration-runner.test.mjs
+++ b/projects/product/services/buildr/test/integration-candidate-release/release-orchestration-runner.test.mjs
@@ -31,11 +31,15 @@ function evidence() {
 function closeoutDependencies(overrides = {}) {
   let task = { taskId: 'release-1.0.0-rc.1', status: 'active', result: null };
   let environmentStatus = 'ready';
+  let gitCloseoutInput = null;
   const calls = [];
   const dependencies = {
     inspectHostedReleaseTransaction: async () => ({ status: 'passed', evidenceIdentity: digest('4'), evidence: evidence(), effects: [], nextActions: [] }),
     reconcilePublishedReleaseWithDev: () => ({ status: 'passed', identity: digest('5'), recoveryIdentity: digest('6'), effects: [], nextActions: [] }),
-    closeoutReleaseGitResources: () => ({ status: 'passed', identity: digest('7'), formalReleaseRef: { disposition: 'retained-and-verified', ref: 'refs/heads/release-1.0.0-rc.1' }, effects: [{ type: 'selection-cleaned' }], nextActions: [] }),
+    closeoutReleaseGitResources: (input) => {
+      gitCloseoutInput = input;
+      return { status: 'passed', identity: digest('7'), formalReleaseRef: { disposition: 'retained-and-verified', ref: 'refs/heads/release-1.0.0-rc.1' }, effects: [{ type: 'selection-cleaned' }], nextActions: [] };
+    },
     inspectTaskRecord: () => ({ record: task, recordDigest: digest(task.status === 'active' ? '8' : '9') }),
     inspectTaskEnvironment: () => ({ status: environmentStatus, environment: { workspace: { root: '/workspace' }, controller: { sourceRoot: '/workspace/projects/product/services/buildr', identity: digest('a') }, runtimeInvocation: { executable: '/node' } } }),
     resolveRetainedController: () => ({ executable: '/node', argsPrefix: ['/workspace/projects/product/services/buildr/bin/buildr.mjs'], workspaceRoot: '/workspace' }),
@@ -53,7 +57,7 @@ function closeoutDependencies(overrides = {}) {
     },
     ...overrides,
   };
-  return { dependencies, calls, getTask: () => task, setTask: (value) => { task = value; }, setEnvironmentStatus: (value) => { environmentStatus = value; } };
+  return { dependencies, calls, getTask: () => task, getGitCloseoutInput: () => gitCloseoutInput, setTask: (value) => { task = value; }, setEnvironmentStatus: (value) => { environmentStatus = value; } };
 }
 
 test('prepare-dispatch has no effects and returns the unique current approval request', async () => {
@@ -94,6 +98,9 @@ test('closeout completes every owner in order and emits compact timeline output'
   }, fixture.dependencies);
   assert.equal(value.status, 'passed');
   assert.equal(fixture.getTask().result.noChange, true);
+  assert.equal(fixture.getGitCloseoutInput().publicationEvidence.identity, digest('4'));
+  assert.ok(fixture.calls[0].includes('--expected-record'));
+  assert.deepEqual(fixture.calls[1].slice(4, 8), ['--expected-source', `workspace=${commit('a')}`, '--delivered-ref', `workspace=${commit('a')}`]);
   assert.deepEqual(fixture.calls.map((args) => args.slice(0, 3)), [['task', 'complete', 'release-1.0.0-rc.1'], ['task', 'environment', 'cleanup'], ['doctor', '--target', '/workspace']]);
   assert.equal(value.lifecycle.phase, 'closed');
   assert.equal(value.timeline.terminalStatus, 'closed');

--- a/projects/product/services/buildr/test/system/worktree-create.test.mjs
+++ b/projects/product/services/buildr/test/system/worktree-create.test.mjs
@@ -416,3 +416,29 @@ test('已核验不同提交编号的交付可由环境CLI清理，错误输入�
   assert.equal(taskRuntime.inspectTaskRecord(root, taskId).record.status, 'completed');
   assert.equal(buildr([...base, ...inputs]).status, 'cleaned');
 });
+
+test('no-change协调任务可用非任务分支持有的精确交付提交清理前进后的工作树', (t) => {
+  const root = fixtureWorkspace(t);
+  const taskId = 'reviewed-no-change-cleanup';
+  createTask(root, taskId);
+  const prepared = buildr(['task', 'environment', 'prepare', taskId, '--plan', noServicePlan(taskId), '--agent', 'codex', '--target', root, '--json']);
+  assert.equal(prepared.status, 'ready');
+  const checkout = prepared.execution.workdir;
+  fs.writeFileSync(path.join(checkout, 'release-result.txt'), 'published release\n');
+  command(checkout, 'git', ['add', '--', 'release-result.txt']);
+  command(checkout, 'git', ['commit', '-m', 'release-owned result']);
+  const source = command(checkout, 'git', ['rev-parse', 'HEAD']).stdout.trim();
+  command(root, 'git', ['branch', 'published-main', source]);
+  taskRuntime.completeTaskRecord(root, taskId, { summary: 'Coordination completed without an independent code contribution.', noChange: true });
+
+  const cleaned = buildr([
+    'task', 'environment', 'cleanup', taskId,
+    '--expected-source', `workspace=${source}`,
+    '--delivered-ref', `workspace=${source}`,
+    '--target', root, '--json',
+  ]);
+  assert.equal(cleaned.status, 'cleaned', JSON.stringify(cleaned.diagnostic));
+  assert.equal(fs.existsSync(checkout), false);
+  assert.equal(command(root, 'git', ['rev-parse', 'published-main']).stdout.trim(), source);
+  assert.equal(buildr(['task', 'environment', 'cleanup', taskId, '--target', root, '--json']).status, 'cleaned');
+});

--- a/projects/product/services/buildr/tools/release/release-git-convergence.mjs
+++ b/projects/product/services/buildr/tools/release/release-git-convergence.mjs
@@ -8,7 +8,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 import { sameFilesystemPath } from '../../src/infrastructure/filesystem/filesystem-path-identity.mjs';
-import { cleanupReleaseSelection, inspectReleaseSelection, reconcileReleaseSelectionWithMain } from './release-selection.mjs';
+import { cleanupReleaseSelection, inspectReleaseSelection, inspectReleaseSelectionCleanup, reconcileReleaseSelectionWithMain } from './release-selection.mjs';
 import { validateReleaseTransactionEvidence } from './release-transaction-evidence.mjs';
 
 export const releaseGitConvergenceSchema = 'buildr.release-git-convergence/v1';
@@ -462,6 +462,11 @@ export function closeoutReleaseGitResources(options = {}, dependencies = {}) {
     const version = requiredVersion(options.version);
     const generation = requiredGeneration(options.generation);
     const expectedCommit = requiredSha(options.expectedCommit, 'expectedCommit');
+    const publicationEvidence = passedPublication(options.publicationEvidence);
+    const publishedSource = releaseSource(publicationEvidence.context);
+    if (publishedSource.version !== version || publishedSource.releaseCommit !== expectedCommit) {
+      return blocked(operation, 'release-closeout-publication-mismatch', 'Publication evidence does not match the requested release source.', { version, generation, expectedCommit });
+    }
     const formalBranch = branchFor(version);
     const carrierBranch = releaseCarrierBranchFor(version, generation);
     const remoteRefs = remoteHeads(repo, remote, [formalBranch, carrierBranch], dependencies);
@@ -477,6 +482,11 @@ export function closeoutReleaseGitResources(options = {}, dependencies = {}) {
       if (worktree.HEAD !== expectedCommit) findings.push({ code: 'release-worktree-head-drift', path: worktree.worktree, ref: worktree.branch, expected: expectedCommit, actual: worktree.HEAD ?? null });
     }
     if (findings.length) return blocked(operation, 'release-closeout-identity-unknown', 'Release closeout found resources whose ownership or identity cannot be proved.', { version, generation, expectedCommit, findings });
+
+    const selectionCleanupInspection = inspectReleaseSelectionCleanup({ repo, version, publicationEvidence }, dependencies);
+    if (selectionCleanupInspection.status !== 'ready') {
+      return blocked(operation, 'release-selection-cleanup-blocked', selectionCleanupInspection.diagnostic?.message ?? 'Local selection cleanup is not ready.', { version, generation, expectedCommit, selectionCleanupInspection });
+    }
 
     const effects = [];
     if (ownedWorktrees.length && options.authorizeLocalSelectionCleanup !== true) {
@@ -509,7 +519,7 @@ export function closeoutReleaseGitResources(options = {}, dependencies = {}) {
     if (options.authorizeLocalSelectionCleanup !== true) {
       return blocked(operation, 'release-selection-cleanup-authorization-required', 'Deleting the local release branch and lifecycle refs requires explicit closeout authorization.', { version, generation, expectedCommit, effects });
     }
-    const selectionCleanup = cleanupReleaseSelection({ repo, version, confirm: true, executionBinding: options.executionBinding }, dependencies);
+    const selectionCleanup = cleanupReleaseSelection({ repo, version, confirm: true, publicationEvidence }, dependencies);
     if (selectionCleanup.status !== 'passed') return blocked(operation, 'release-selection-cleanup-blocked', selectionCleanup.diagnostic?.message ?? 'Local selection cleanup failed.', { version, generation, expectedCommit, effects, selectionCleanup });
     effects.push(...selectionCleanup.effects);
     const closeoutIdentity = identity({ version, generation, expectedCommit, formalReleaseRef: expectedCommit, carrier: 'absent', selection: 'absent' });

--- a/projects/product/services/buildr/tools/release/release-orchestration-runner.mjs
+++ b/projects/product/services/buildr/tools/release/release-orchestration-runner.mjs
@@ -200,6 +200,7 @@ async function closeout(options, dependencies) {
     version: options.version,
     generation,
     expectedCommit,
+    publicationEvidence: evidence,
     authorizeCarrierCleanup: options.authorizeCarrierCleanup === true,
     authorizeLocalSelectionCleanup: options.authorizeLocalSelectionCleanup === true,
   }, dependencies.gitDependencies);
@@ -232,7 +233,7 @@ async function closeout(options, dependencies) {
   let taskCompletion;
   if (taskResult.record.status === 'completed' && taskResult.record.result?.noChange === true) taskCompletion = { status: 'completed', recordDigest: taskResult.recordDigest, effects: [] };
   else if (taskResult.record.status === 'active') {
-    taskCompletion = invokeRetained(controller, ['task', 'complete', options.releaseTask, '--summary', options.completionSummary ?? `Release ${options.version} Publication、dev provenance与资源收尾已完成。`, '--no-change', '--target', root, '--json']);
+    taskCompletion = invokeRetained(controller, ['task', 'complete', options.releaseTask, '--summary', options.completionSummary ?? `Release ${options.version} Publication、dev provenance与资源收尾已完成。`, '--no-change', '--expected-record', taskResult.recordDigest, '--target', root, '--json']);
     taskResult = inspectTask(root, options.releaseTask);
   } else taskCompletion = { status: 'blocked', effects: [], nextActions: [`Release Task状态${taskResult.record.status}不能作为closeout完成事实。`] };
   steps.push(step('task-record', 'complete-no-change', taskCompletion, taskCompletion.effects?.length ? 'executed' : 'reused'));
@@ -241,7 +242,12 @@ async function closeout(options, dependencies) {
   const currentEnvironment = inspectEnvironment(root, options.releaseTask);
   let environmentCleanup = currentEnvironment.status === 'cleaned'
     ? { status: 'cleaned', effects: [] }
-    : invokeRetained(controller, ['task', 'environment', 'cleanup', options.releaseTask, '--target', root, '--json']);
+    : invokeRetained(controller, [
+      'task', 'environment', 'cleanup', options.releaseTask,
+      '--expected-source', `workspace=${context.release.sourceCommit}`,
+      '--delivered-ref', `workspace=${context.convergence.mainCommit}`,
+      '--target', root, '--json',
+    ]);
   steps.push(step('task-environment', 'cleanup', environmentCleanup, environmentCleanup.effects?.length ? 'executed' : 'reused'));
   if (environmentCleanup.status !== 'cleaned') return blocked(options, 'closeout', { evidence, context, reconciliation, gitCloseout, lifecycle: activeLifecycle, taskCompletion, environmentCleanup }, steps, environmentCleanup, '恢复Task Environment cleanup后重试。');
 

--- a/projects/product/services/buildr/tools/release/release-selection.mjs
+++ b/projects/product/services/buildr/tools/release/release-selection.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 import { parseArguments, requireOption } from './release-files.mjs';
 import { validateReleaseExecutionBinding } from './release-execution-binding.mjs';
+import { validateReleaseTransactionEvidence } from './release-transaction-evidence.mjs';
 
 export const releaseSelectionSchema = 'buildr.release-selection/v1';
 export const releaseSelectionSchemaVersion = releaseSelectionSchema;
@@ -71,6 +72,29 @@ function requireExecutionBinding(options, repo) {
   const binding = validateReleaseExecutionBinding(options.executionBinding, { repo });
   if (binding.version !== options.version) throw new Error(`Release execution binding version ${binding.version} does not match ${options.version}.`);
   return binding;
+}
+
+function requireCleanupAuthority(options, repo, state) {
+  if (options.executionBinding) {
+    const executionBinding = requireExecutionBinding(options, repo);
+    return { kind: 'task-environment', identity: executionBinding.identity };
+  }
+  const evidence = validateReleaseTransactionEvidence(options.publicationEvidence);
+  const context = evidence.context;
+  if (evidence.status !== 'passed'
+      || evidence.release.registryPublished !== true
+      || evidence.release.registrySmoke !== 'passed'
+      || !evidence.release.githubRelease) {
+    throw new Error('Release cleanup requires complete passed Publication evidence.');
+  }
+  if (context.release.version !== options.version
+      || context.selection.version !== options.version
+      || context.selection.status !== 'frozen'
+      || (state && (context.selection.releaseHead !== state.releaseHead
+        || context.selection.generation !== state.generation))) {
+    throw new Error('Publication evidence does not match the current frozen release selection.');
+  }
+  return { kind: 'publication', identity: evidence.identity };
 }
 
 function ancestor(older, newer, repo, dependencies) {
@@ -520,25 +544,44 @@ export function abandonReleaseSelection(options = {}, dependencies = {}) {
   }
 }
 
-export function cleanupReleaseSelection(options = {}, dependencies = {}) {
+export function inspectReleaseSelectionCleanup(options = {}, dependencies = {}) {
   const version = options.version;
   try {
     const required = requiredVersion(version);
-    if (options.confirm !== true) throw new Error('Local release cleanup requires explicit confirmation.');
     const repo = path.resolve(options.repo ?? process.cwd());
-    requireExecutionBinding(options, repo);
     const branch = branchFor(required);
     const branchRef = `refs/heads/${branch}`;
     const currentBranch = runGit(['branch', '--show-current'], repo, dependencies).stdout.trim();
     if (currentBranch === branch) throw new Error(`Cannot cleanup checked-out release branch ${branch}; checkout another branch first.`);
     const refs = refsUnder(`refs/buildr/release/${required}/`, repo, dependencies).map((entry) => entry.ref);
     const branchExists = refExists(branchRef, repo, dependencies);
+    const state = branchExists || refs.length ? readState(options, dependencies) : null;
+    const cleanupAuthority = requireCleanupAuthority(options, repo, state);
+    return { schemaVersion: releaseSelectionSchema, operation: 'inspect-cleanup', version: required, branch, status: 'ready', branchExists, refs, cleanupAuthority, effects: [], nextActions: [] };
+  } catch (error) {
+    return errorResult('inspect-cleanup', version, error, { code: 'release_selection_cleanup_blocked' });
+  }
+}
+
+export function cleanupReleaseSelection(options = {}, dependencies = {}) {
+  const version = options.version;
+  try {
+    const required = requiredVersion(version);
+    if (options.confirm !== true) throw new Error('Local release cleanup requires explicit confirmation.');
+    const repo = path.resolve(options.repo ?? process.cwd());
+    const inspected = inspectReleaseSelectionCleanup(options, dependencies);
+    if (inspected.status !== 'ready') return { ...inspected, operation: 'cleanup' };
+    const branch = inspected.branch;
+    const branchRef = `refs/heads/${branch}`;
+    const refs = inspected.refs;
+    const branchExists = inspected.branchExists;
+    const cleanupAuthority = inspected.cleanupAuthority;
     if (!branchExists && refs.length === 0) {
-      return { schemaVersion: releaseSelectionSchema, operation: 'cleanup', version: required, branch, status: 'passed', action: 'already-cleaned', effects: [], nextActions: [] };
+      return { schemaVersion: releaseSelectionSchema, operation: 'cleanup', version: required, branch, status: 'passed', action: 'already-cleaned', cleanupAuthority, effects: [], nextActions: [] };
     }
     if (branchExists) runGit(['branch', '-D', branch], repo, dependencies);
     for (const ref of refs) runGit(['update-ref', '-d', ref], repo, dependencies);
-    return { schemaVersion: releaseSelectionSchema, operation: 'cleanup', version: required, branch, status: 'passed', action: 'cleaned', effects: [...(branchExists ? [{ type: 'branch-deleted', ref: branchRef }] : []), ...refs.map((ref) => ({ type: 'lifecycle-ref-deleted', ref }))], nextActions: [] };
+    return { schemaVersion: releaseSelectionSchema, operation: 'cleanup', version: required, branch, status: 'passed', action: 'cleaned', cleanupAuthority, effects: [...(branchExists ? [{ type: 'branch-deleted', ref: branchRef }] : []), ...refs.map((ref) => ({ type: 'lifecycle-ref-deleted', ref }))], nextActions: [] };
   } catch (error) {
     return errorResult('cleanup', version, error, { code: 'release_selection_cleanup_blocked', nextActions: ['确认本地 branch 未 checkout、资源ownership明确且传入 --confirm 后重试；正式远端release ref由独立owner核验。'] });
   }


### PR DESCRIPTION
rc.29 已发布，但发布后本机收尾在清理本地 release 集合时失败。发布编排器没有向 selection cleanup 传递执行绑定；更根本的问题是发布引用清理和任务环境清理共用了错误的授权语义。

本改动按现有规范恢复职责：

- release Git owner 使用完整 Publication evidence 校验 version、generation 和 release source，清理自己的 carrier、local release branch 和 lifecycle refs；不依赖仍可执行的 Task Environment。
- Task Environment 继续独占任务工作树清理。发布编排器传入精确 `release source → main merge` 映射，Git provider 复核 source HEAD、clean、registration，并要求交付提交由非任务 ref 持有。
- `no-change` 只表示协调任务没有独立业务代码贡献；存在精确交付映射时，不再错误要求 checkout HEAD 等于环境创建时 HEAD。
- 所有 selection cleanup 前置检查在第一项删除前完成；任务完成补充 `--expected-record`。

验证新增真实 Git 收尾串联：Publication evidence → release Git closeout → Task complete → Environment cleanup，并检查正式远端 release ref 保留、carrier/本地集合清理、精确交付参数传递和重复 closeout 幂等。相关 58 项测试全部通过；正式受影响验证与 GitHub 双平台检查运行中。

本改动只恢复 rc.29 本机收尾，不重新发布版本，不修改 tag、npm 或 GitHub Release。
