### PR TITLE
fix(release): 发布成功后清理本地标签

### DIFF
--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/.buildr/knowledge-impact.yml
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/.buildr/knowledge-impact.yml
@@ -1,0 +1,14 @@
+schemaVersion: buildr.knowledge-impact/v1
+change: cleanup-local-release-tag
+operation: assess
+treeIdentity: planning
+impacts:
+  - type: brief
+    target: brief.md
+    reason: 记录本地与远端Tag的收尾边界
+    status: aligned
+    sourceIdentities:
+      - proposal.md
+      - design.md
+      - specs/release-collection-model/spec.md
+unresolvedItems: []

--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/.openspec.yaml
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/brief.md
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/brief.md
@@ -1,0 +1,34 @@
+# 发布成功后清理本地 Tag
+
+## 摘要
+
+正式发布成功并核验远端 Tag 后，release closeout 删除本地同名 Tag，保留全部远端和公开发布事实。
+
+## 背景与问题
+
+当前 closeout 已删除临时 carrier、本地 release branch、lifecycle refs 与任务工作树，却保留可从远端重建的本地 Tag，导致本机必需资源清理不完整。
+
+## 目标与非目标
+
+- 目标：删除与 Publication evidence 和远端 Tag 精确匹配的本地 Tag；支持缺失幂等；漂移时零删除。
+- 非目标：不删除或移动远端 Tag，不重新发布 npm 或 GitHub Release，不扫描其他版本。
+
+## 核心流程
+
+release Git owner读取 Publication evidence，核验远端 Tag对象，再核验本地同名 Tag。全部检查通过后，将本地 Tag与其他本地发布资源一起清理；Task Environment仍只清理任务工作树和环境回执。
+
+## 影响、风险与兼容性
+
+本地 Tag删除后可从正式远端重建。错误Tag或网络读取失败时保留现场。公开安装、版本、Tag URL、npm dist-tag和远端release分支不变。
+
+## 验收摘要
+
+- 正式远端 Tag始终保留并与发布证据匹配。
+- 本地同名 Tag删除或幂等确认缺失。
+- Tag漂移时任何本地发布资源均不删除。
+- 重复closeout不重复发布或产生额外Git副作用。
+
+## 技术入口
+
+- `tools/release/release-git-convergence.mjs`
+- `test/integration-candidate-release/release-git-convergence.test.mjs`

--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/design.md
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/design.md
@@ -1,0 +1,42 @@
+## Context
+
+受保护发布工作流创建远端 annotated Tag。后续 release closeout 已通过 Publication evidence 核验 Tag、npm、GitHub Release 和 release source，并清理临时 carrier、本地发布分支、lifecycle refs 与工作树，但没有处理本地同名 Tag。该 Tag 可由正式远端重建，不属于必须保留的本机恢复资源。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 远端正式 Tag 保持不变，本地同名 Tag 在完整预检后删除。
+- 本地 Tag 缺失时重复 closeout 幂等成功。
+- 本地或远端 Tag 与 Publication evidence 不匹配时零删除失败。
+- Tag 清理结果进入 release Git closeout effects 和资源投影。
+
+**Non-Goals:**
+
+- 不删除或移动远端 Tag。
+- 不重发 npm、GitHub Release 或发布工作流。
+- 不扫描或清理其他版本、其他仓库或非 Buildr Tag。
+
+## Decisions
+
+1. **由 Release Git Convergence owner 清理本地 Tag。** Tag 是发布 Git 资源，不属于 Task Environment 工作树资源；Task Environment 不读取或删除 Tag。
+2. **以 Publication evidence 和远端 Tag readback 作为清理授权。** owner 从 evidence 取得正式 Tag 名和提交，要求远端 `refs/tags/<tag>` 精确匹配，再检查本地同名 Tag。
+3. **删除 annotated Tag ref，而不是 Tag 指向的 commit。** 本地 ref 删除后，正式远端 Tag、release branch、main、npm 与 GitHub Release仍持有发布事实。
+4. **全部预检先于任何删除。** carrier、selection 和 local Tag 的归属/identity/授权一次检查完成；任一冲突保持零 effects。
+5. **幂等清理。** 本地 Tag 已缺失返回 `already-cleaned`；只有本地同名 Tag 指向正式远端 Tag 对象时才删除。
+
+备选方案是在 Task Environment cleanup 中删除 Tag；该方案会让环境 owner 管理不属于 Environment Receipt 的发布资源，因此不采用。
+
+## Risks / Trade-offs
+
+- [本地 Tag 被用户改写] → 与远端 Tag 对象不一致时 fail closed，保留现场。
+- [远端 Tag 不可读取] → 不删除本地 Tag，避免把网络失败当作远端事实。
+- [删除后用户需要本地 Tag] → 可从正式远端显式 fetch 重建；不影响任何公开发布结果。
+
+## Migration Plan
+
+发布新版实现后，对已经成功发布但本地 Tag 尚存的版本重跑同一 closeout。owner 复用 Publication evidence，仅完成未完成的本地 Tag 和其他本机资源清理，不重复 Publication。
+
+## Open Questions
+
+无。

--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/proposal.md
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+正式发布成功后，本地同名 Tag 只是远端正式 Tag 的可重建投射，不应作为必需本地资源长期保留。当前 closeout 已清理本地发布分支、生命周期 refs、generation carrier 和任务工作树，却留下本地 Tag，导致“发布资源已清理”的结果与本机 Git 现场不一致。
+
+## What Changes
+
+- 发布成功且 Publication evidence、远端 Tag 名称、Tag 提交与目标 release source 全部匹配时，删除本地同名 Tag。
+- 正式远端 Tag、GitHub Release、npm version/dist-tag 和正式远端 `release-<version>` 分支保持不变。
+- 本地 Tag 缺失时幂等返回已清理；本地 Tag 指向不匹配时停止清理并保留现场。
+- 在任何删除前预检本地 Tag 与远端正式事实，防止发生部分清理。
+
+不包含破坏性变更；用户可见安装与发布接口保持不变。
+
+## Capabilities
+
+### New Capabilities
+
+无。
+
+### Modified Capabilities
+
+- `release-collection-model`：扩展发布成功后的必需本地资源清理范围，明确远端 Tag 保留、本地同名 Tag 删除及幂等/漂移处理。
+
+## Impact
+
+- OpenSpec：`release-collection-model` 的 closeout requirement 与 scenarios。
+- 实现：发布 Git 收敛与 release closeout 结果投影。
+- 验证：真实 Git Tag 创建、远端核验、本地删除、错误指向拒绝与重复 closeout。

--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/specs/release-collection-model/spec.md
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/specs/release-collection-model/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Lifecycle state 必须独立、可重建且 fail closed
+Freeze、reopen、abandon和closeout MUST使用独立Git lifecycle refs与current owner facts，并保持幂等、compare-and-swap与授权边界。current freeze或abandon状态 MUST阻止update；只有显式reopen成功后才能继续逐commit update。Closeout MUST区分正式远端`release-<version>`、正式远端Tag、remote-tracking projection与owner-owned本地/中间资源：正式远端release ref和正式远端Tag默认保留并核验；本地release branch、全部selection lifecycle refs、owned worktree、generation carrier与本地同名Tag属于必需清理资源；remote-tracking ref存在 MUST NOT阻止本地清理。
+
+#### Scenario: freeze and inspect
+- **WHEN** open集合被要求 freeze
+- **THEN** owner MUST写入current frozen ref与不可变`freezes/<generation>`历史ref，并返回包含按generation排序`freezeHistory`的stable selection identity；重复 freeze 在HEAD和历史ref未变时幂等成功
+- **AND** branch内容变化、current frozen ref与HEAD不一致或历史generation ref漂移时read model MUST标记stale或blocked
+
+#### Scenario: reopen current freeze
+- **WHEN** current selection为frozen、worktree clean且维护者提供显式confirmation与非空reason
+- **THEN** owner MUST确保当前generation历史freeze不可变保存，再按expected commit删除current frozen ref并返回`ready`
+- **AND** update仍需后续独立授权；旧Candidate、artifact、readiness与transaction context MUST因current selection status/identity变化而stale
+
+#### Scenario: reopen遇到ref竞争或错误状态
+- **WHEN** selection不是current frozen、历史freeze ref指向其他commit、current frozen ref漂移、worktree dirty或confirmation/reason缺失
+- **THEN** reopen MUST fail closed并报告current facts与已发生effects
+- **AND** MUST NOT继续update、移动remote branch、删除历史freeze或自动改变策略
+
+#### Scenario: 正式远端release ref存在时清理本地资源
+- **WHEN** owner明确closeout一个已发布release，正式远端`release-<version>`精确等于冻结release commit，正式远端Tag与Publication evidence匹配，且本地branch、lifecycle refs、owned worktree或本地同名Tag仍存在
+- **THEN** closeout MUST保留正式远端release ref和正式远端Tag，并在显式本地cleanup确认后删除owner可证明的本地branch、全部current/history lifecycle refs、owned worktree与本地同名Tag
+- **AND** remote-tracking projection存在 MUST NOT阻止本地资源清理
+
+#### Scenario: 本地Tag已缺失
+- **WHEN** Publication evidence与正式远端Tag匹配，且本地同名Tag已经不存在
+- **THEN** closeout MUST把本地Tag返回为`already-cleaned`
+- **AND** MUST NOT重复创建、fetch、移动或删除远端Tag
+
+#### Scenario: 本地或远端Tag漂移
+- **WHEN** 正式远端Tag与Publication evidence不匹配，或本地同名Tag存在但与正式远端Tag对象不一致
+- **THEN** closeout MUST在任何本地/中间资源删除前fail closed并报告expected/actual Tag identity
+- **AND** MUST NOT删除、移动或覆盖本地或远端Tag
+
+#### Scenario: abandon and cleanup
+- **WHEN** owner明确abandon一个未发布release集合
+- **THEN** abandon MUST阻止后续Candidate/update/reopen且保留既有Git/Task事实
+- **AND** 未取得独立cleanup授权时 MUST保留本地与远端资源

--- a/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/tasks.md
+++ b/projects/product/openspec/changes/archive/2026-09-01-cleanup-local-release-tag/tasks.md
@@ -1,0 +1,9 @@
+## 1. 发布 Tag 清理实现
+
+- [x] 1.1 扩展 release Git closeout，在完整 Publication/远端 Tag/本地 Tag 预检后删除本地同名 Tag并记录结果
+- [x] 1.2 保持正式远端 Tag、远端 release ref、npm 与 GitHub Release不变，并支持本地 Tag 已缺失的幂等恢复
+
+## 2. 验证与当前认知
+
+- [x] 2.1 增加真实 Git annotated Tag 的成功、缺失、漂移和重复 closeout 回归
+- [x] 2.2 更新 Change Brief 与知识影响证据，完成严格 OpenSpec 校验和直接相关测试

--- a/projects/product/openspec/specs/release-collection-model/spec.md
+++ b/projects/product/openspec/specs/release-collection-model/spec.md
@@ -139,7 +139,7 @@ Update MUST按调用方给出的单个 source commit 执行 `git cherry-pick -x`
 - **AND** MUST不自动解决、继续选择、reset、rebase、force push 或报告部分成功
 
 ### Requirement: Lifecycle state 必须独立、可重建且 fail closed
-Freeze、reopen、abandon和closeout MUST使用独立Git lifecycle refs与current owner facts，并保持幂等、compare-and-swap与授权边界。current freeze或abandon状态 MUST阻止update；只有显式reopen成功后才能继续逐commit update。Closeout MUST区分正式远端`release-<version>`、remote-tracking projection与owner-owned本地/中间资源：正式远端release ref默认保留并核验，本地release branch、全部selection lifecycle refs、owned worktree与generation carrier属于必需清理资源；remote-tracking ref存在 MUST NOT阻止本地清理。
+Freeze、reopen、abandon和closeout MUST使用独立Git lifecycle refs与current owner facts，并保持幂等、compare-and-swap与授权边界。current freeze或abandon状态 MUST阻止update；只有显式reopen成功后才能继续逐commit update。Closeout MUST区分正式远端`release-<version>`、正式远端Tag、remote-tracking projection与owner-owned本地/中间资源：正式远端release ref和正式远端Tag默认保留并核验；本地release branch、全部selection lifecycle refs、owned worktree、generation carrier与本地同名Tag属于必需清理资源；remote-tracking ref存在 MUST NOT阻止本地清理。
 
 #### Scenario: freeze and inspect
 - **WHEN** open集合被要求 freeze
@@ -157,9 +157,19 @@ Freeze、reopen、abandon和closeout MUST使用独立Git lifecycle refs与curren
 - **AND** MUST NOT继续update、移动remote branch、删除历史freeze或自动改变策略
 
 #### Scenario: 正式远端release ref存在时清理本地资源
-- **WHEN** owner明确closeout一个已发布release，正式远端`release-<version>`精确等于冻结release commit，且本地branch、lifecycle refs或owned worktree仍存在
-- **THEN** closeout MUST保留正式远端release ref，并在显式本地cleanup确认后删除owner可证明的本地branch、全部current/history lifecycle refs与owned worktree
+- **WHEN** owner明确closeout一个已发布release，正式远端`release-<version>`精确等于冻结release commit，正式远端Tag与Publication evidence匹配，且本地branch、lifecycle refs、owned worktree或本地同名Tag仍存在
+- **THEN** closeout MUST保留正式远端release ref和正式远端Tag，并在显式本地cleanup确认后删除owner可证明的本地branch、全部current/history lifecycle refs、owned worktree与本地同名Tag
 - **AND** remote-tracking projection存在 MUST NOT阻止本地资源清理
+
+#### Scenario: 本地Tag已缺失
+- **WHEN** Publication evidence与正式远端Tag匹配，且本地同名Tag已经不存在
+- **THEN** closeout MUST把本地Tag返回为`already-cleaned`
+- **AND** MUST NOT重复创建、fetch、移动或删除远端Tag
+
+#### Scenario: 本地或远端Tag漂移
+- **WHEN** 正式远端Tag与Publication evidence不匹配，或本地同名Tag存在但与正式远端Tag对象不一致
+- **THEN** closeout MUST在任何本地/中间资源删除前fail closed并报告expected/actual Tag identity
+- **AND** MUST NOT删除、移动或覆盖本地或远端Tag
 
 #### Scenario: abandon and cleanup
 - **WHEN** owner明确abandon一个未发布release集合

--- a/projects/product/services/buildr/test/integration-candidate-release/release-git-convergence.test.mjs
+++ b/projects/product/services/buildr/test/integration-candidate-release/release-git-convergence.test.mjs
@@ -90,8 +90,9 @@ function convergenceFixture() {
   git(seed, 'checkout', 'main');
   git(seed, 'checkout', selected, '--', '.');
   const mainCommit = commit(seed, 'squash release', {});
+  git(seed, 'tag', '-a', 'v0.1.0-rc.5', mainCommit, '-m', 'release 0.1.0-rc.5');
   git(seed, 'remote', 'add', 'origin', remote);
-  git(seed, 'push', 'origin', 'dev', 'main');
+  git(seed, 'push', 'origin', 'dev', 'main', 'refs/tags/v0.1.0-rc.5');
   const release = releaseWorktree(root, remote, base);
   const created = createReleaseSelection({ version: '0.1.0-rc.5', repo: release.work, devRef: 'origin/dev', baseline: base, executionBinding: release.binding() });
   assert.equal(created.status, 'passed', JSON.stringify(created));
@@ -345,6 +346,10 @@ test('黄金生命周期以同一active Task等待授权并在零中间资源clo
   });
   assert.equal(first.status, 'passed', JSON.stringify(first));
   assert.equal(first.formalReleaseRef.disposition, 'retained-and-verified');
+  assert.equal(first.tag.local, 'absent');
+  assert.equal(first.tag.remote, 'retained-and-verified');
+  assert.equal(spawnSync('git', ['show-ref', '--verify', '--quiet', 'refs/tags/v0.1.0-rc.5'], { cwd: data.controller }).status, 1);
+  assert.notEqual(git(data.controller, 'ls-remote', 'origin', 'refs/tags/v0.1.0-rc.5'), '');
   assert.equal(git(data.work, 'ls-remote', 'origin', 'refs/heads/release-0.1.0-rc.5').startsWith(data.releaseCommit), true);
   assert.equal(git(data.work, 'ls-remote', 'origin', `refs/heads/${carrier}`), '');
   const second = closeoutReleaseGitResources({
@@ -372,6 +377,29 @@ test('黄金生命周期以同一active Task等待授权并在零中间资源clo
   assert.equal(closed.status, 'passed');
   assert.equal(closed.phase, 'closed');
   assert.equal(closed.releaseTask.taskId, waiting.releaseTask.taskId);
+});
+
+test('本地Tag漂移在任何发布资源删除前阻止closeout', (t) => {
+  const data = convergenceFixture();
+  t.after(() => fs.rmSync(data.root, { recursive: true, force: true }));
+  const carrier = releaseCarrierBranchFor('0.1.0-rc.5', data.frozen.generation);
+  git(data.controller, 'branch', carrier, data.releaseCommit);
+  git(data.controller, 'push', 'origin', `${carrier}:${carrier}`);
+  git(data.controller, 'tag', '-f', 'v0.1.0-rc.5', data.base);
+
+  const blocked = closeoutReleaseGitResources({
+    repo: data.controller,
+    version: '0.1.0-rc.5',
+    generation: data.frozen.generation,
+    expectedCommit: data.releaseCommit,
+    authorizeCarrierCleanup: true,
+    authorizeLocalSelectionCleanup: true,
+    publicationEvidence: data.publicationEvidence,
+  });
+  assert.equal(blocked.status, 'blocked');
+  assert.equal(blocked.diagnostic.code, 'release-closeout-local-tag-drift');
+  assert.notEqual(git(data.controller, 'ls-remote', 'origin', `refs/heads/${carrier}`), '');
+  assert.equal(git(data.controller, 'rev-parse', 'release-0.1.0-rc.5'), data.releaseCommit);
 });
 
 test('发布编排真实调用Git closeout并把精确交付映射交给Environment owner', async (t) => {

--- a/projects/product/services/buildr/tools/release/release-git-convergence.mjs
+++ b/projects/product/services/buildr/tools/release/release-git-convergence.mjs
@@ -86,6 +86,25 @@ function remoteHeads(repo, remote, branches, dependencies) {
   return Object.fromEntries(branches.map((branch) => [branch, found.get(`refs/heads/${branch}`) ?? null]));
 }
 
+function remoteTag(repo, remote, tag, dependencies) {
+  const ref = `refs/tags/${tag}`;
+  const result = git(repo, ['ls-remote', '--tags', remote, ref, `${ref}^{}`], dependencies);
+  const entries = new Map(result.stdout.split(/\r?\n/u).filter(Boolean).map((line) => {
+    const [commit, name] = line.trim().split(/\s+/u);
+    return [name, commit];
+  }));
+  const object = entries.get(ref) ?? null;
+  return object ? { ref, object, target: entries.get(`${ref}^{}`) ?? object } : null;
+}
+
+function localTag(repo, tag, dependencies) {
+  const ref = `refs/tags/${tag}`;
+  const object = git(repo, ['rev-parse', '--verify', ref], dependencies, { allowFailure: true });
+  if (object.status !== 0) return null;
+  const target = git(repo, ['rev-parse', '--verify', `${ref}^{}`], dependencies, { allowFailure: true });
+  return target.status === 0 ? { ref, object: object.stdout.trim(), target: target.stdout.trim() } : null;
+}
+
 function result(operation, status, data = {}) {
   return {
     schemaVersion: releaseGitConvergenceSchema,
@@ -468,6 +487,16 @@ export function closeoutReleaseGitResources(options = {}, dependencies = {}) {
       return blocked(operation, 'release-closeout-publication-mismatch', 'Publication evidence does not match the requested release source.', { version, generation, expectedCommit });
     }
     const formalBranch = branchFor(version);
+    const tag = publicationEvidence.release.tag;
+    if (tag !== `v${version}`) return blocked(operation, 'release-closeout-tag-name-mismatch', 'Publication evidence Tag does not match the release version.', { version, generation, expectedCommit, expectedTag: `v${version}`, actualTag: tag });
+    const remoteReleaseTag = remoteTag(repo, remote, tag, dependencies);
+    const localReleaseTag = localTag(repo, tag, dependencies);
+    if (!remoteReleaseTag || remoteReleaseTag.target !== publicationEvidence.release.tagCommit) {
+      return blocked(operation, 'release-closeout-remote-tag-drift', 'Remote Tag does not match Publication evidence.', { version, generation, expectedCommit, tag, expectedTarget: publicationEvidence.release.tagCommit, actual: remoteReleaseTag });
+    }
+    if (localReleaseTag && (localReleaseTag.object !== remoteReleaseTag.object || localReleaseTag.target !== remoteReleaseTag.target)) {
+      return blocked(operation, 'release-closeout-local-tag-drift', 'Local Tag does not match the official remote Tag.', { version, generation, expectedCommit, tag, expected: remoteReleaseTag, actual: localReleaseTag });
+    }
     const carrierBranch = releaseCarrierBranchFor(version, generation);
     const remoteRefs = remoteHeads(repo, remote, [formalBranch, carrierBranch], dependencies);
     const localFormal = localBranchCommit(repo, formalBranch, dependencies);
@@ -522,7 +551,12 @@ export function closeoutReleaseGitResources(options = {}, dependencies = {}) {
     const selectionCleanup = cleanupReleaseSelection({ repo, version, confirm: true, publicationEvidence }, dependencies);
     if (selectionCleanup.status !== 'passed') return blocked(operation, 'release-selection-cleanup-blocked', selectionCleanup.diagnostic?.message ?? 'Local selection cleanup failed.', { version, generation, expectedCommit, effects, selectionCleanup });
     effects.push(...selectionCleanup.effects);
-    const closeoutIdentity = identity({ version, generation, expectedCommit, formalReleaseRef: expectedCommit, carrier: 'absent', selection: 'absent' });
+    if (localReleaseTag) {
+      const deleted = git(repo, ['update-ref', '-d', localReleaseTag.ref, localReleaseTag.object], dependencies, { allowFailure: true });
+      if (deleted.status !== 0) return blocked(operation, 'release-local-tag-cleanup-blocked', 'Local Tag changed before cleanup.', { version, generation, expectedCommit, tag, expected: localReleaseTag, effects });
+      effects.push({ type: 'local-release-tag-deleted', ref: localReleaseTag.ref, object: localReleaseTag.object, target: localReleaseTag.target });
+    }
+    const closeoutIdentity = identity({ version, generation, expectedCommit, formalReleaseRef: expectedCommit, remoteTag: remoteReleaseTag.object, localTag: 'absent', carrier: 'absent', selection: 'absent' });
     return result(operation, 'passed', {
       action: effects.length ? 'cleaned' : 'already-cleaned',
       version,
@@ -530,6 +564,7 @@ export function closeoutReleaseGitResources(options = {}, dependencies = {}) {
       expectedCommit,
       identity: closeoutIdentity,
       formalReleaseRef: { ref: `refs/heads/${formalBranch}`, commit: expectedCommit, disposition: 'retained-and-verified' },
+      tag: { ref: remoteReleaseTag.ref, target: remoteReleaseTag.target, object: remoteReleaseTag.object, remote: 'retained-and-verified', local: 'absent' },
       resources: {
         carrier: { ref: `refs/heads/${carrierBranch}`, local: 'absent', remote: 'absent' },
         selection: { localBranch: 'absent', lifecycleRefs: 'absent' },


### PR DESCRIPTION
正式发布完成后，本地同名 Tag 只是正式远端 Tag 的可重建投射。当前 closeout 已清理其他本地/中间资源，却保留本地 Tag。

本改动将本地 Tag 纳入 release Git owner 的必需收尾资源：

- Publication evidence、版本、远端 Tag 名称、annotated Tag 对象和解引用提交全部匹配后，删除本地同名 Tag。
- 正式远端 Tag、远端 release ref、npm 和 GitHub Release 均保留。
- 本地 Tag 已缺失时幂等通过；本地或远端 Tag 漂移时在任何删除前阻塞。
- closeout 结果明确返回远端 retained、本地 absent 和删除 effect。

OpenSpec `release-collection-model` 已同步并归档。真实 Git 回归覆盖成功删除、远端保留、缺失幂等、错误指向零删除和重复 closeout；直接相关10项通过，正式受影响验证和GitHub双平台运行中。

合入后仅恢复已发布 rc.29 的本地收尾，不重新发布版本。
